### PR TITLE
Findbugs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -182,6 +182,11 @@
 	<reporting>
 		<plugins>
 			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>findbugs-maven-plugin</artifactId>
+				<version>2.3.1</version>
+			</plugin>
+			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-report-plugin</artifactId>
 				<version>2.6</version>


### PR DESCRIPTION
Added findbugs without a filter configuration file. I think it feels odd to move the current core and test modules to another sub module as shown here http://mojo.codehaus.org/findbugs-maven-plugin/2.3.1/examples/multi-module-config.html
