### PR TITLE
Findbugs profile

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -13,6 +13,8 @@ Maven:
 - Tested version = 2.2.1
 - 'mvn clean install' to build
 - 'mvn install -DskipTests=true' to skip tests
+- 'mvn install -Dfindbugs.enable=true' to enable findbugs, or enable this
+  property within your settings.xml
 - 'mvn javadoc:aggregate' to just run javadoc (see target/site/apidocs/index.html)
 - 'mvn site' to generate site docs (see target/site/index.html)
 

--- a/pom.xml
+++ b/pom.xml
@@ -140,25 +140,6 @@
 					</execution>
 				</executions>
 			</plugin>
-			<plugin>
-				<groupId>org.codehaus.mojo</groupId>
-				<artifactId>findbugs-maven-plugin</artifactId>
-				<version>2.3.1</version>
-				<configuration>
-					<effort>Max</effort>
-					<threshold>Default</threshold>
-					<xmlOutput>true</xmlOutput>
-				</configuration>
-				<executions>
-					<execution>
-						<id>find-bugs</id>
-						<goals>
-							<goal>findbugs</goal>
-						</goals>
-						<phase>verify</phase>
-					</execution>
-				</executions>
-			</plugin>
 		</plugins>
 	</build>
 	<repositories>
@@ -189,6 +170,55 @@
             </snapshots>
         </pluginRepository>
 	</pluginRepositories>
+    <profiles>
+        <profile>
+            <id>findbugs</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+                <property>
+                    <name>findbugs.enable</name>
+                    <value>true</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+            	    <plugin>
+	            	    <groupId>org.codehaus.mojo</groupId>
+			            <artifactId>findbugs-maven-plugin</artifactId>
+		            	<version>2.3.1</version>
+				        <configuration>
+					        <effort>Max</effort>
+					        <threshold>Default</threshold>
+					        <xmlOutput>true</xmlOutput>
+                        </configuration>
+			            <executions>
+	            		    <execution>
+				                <id>find-bugs</id>
+				            	<goals>
+			            		    <goal>findbugs</goal>
+						        </goals>
+					            <phase>verify</phase>
+		            		</execution>    
+            			</executions>
+			        </plugin>
+                </plugins>
+            </build>
+            <reporting>
+                <plugins>
+		            <plugin>
+				        <groupId>org.codehaus.mojo</groupId>
+				        <artifactId>findbugs-maven-plugin</artifactId>
+				        <version>2.3.1</version>
+		            	<configuration>
+				            <effort>Max</effort>
+					        <threshold>Default</threshold>
+				            <xmlOutput>true</xmlOutput>
+				        </configuration>
+			        </plugin>
+                </plugins>
+            </reporting>
+        </profile>                
+    </profiles>
 	<dependencies>
 		<dependency>
 			<groupId>junit</groupId>
@@ -200,16 +230,6 @@
 	</dependencies>
 	<reporting>
 		<plugins>
-			<plugin>
-				<groupId>org.codehaus.mojo</groupId>
-				<artifactId>findbugs-maven-plugin</artifactId>
-				<version>2.3.1</version>
-				<configuration>
-					<effort>Max</effort>
-					<threshold>Default</threshold>
-					<xmlOutput>true</xmlOutput>
-				</configuration>
-			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-report-plugin</artifactId>


### PR DESCRIPTION
Moved findbugs changes into a profile enabled by the "findbugs.enable" property being set to true.

ex: 
$ mvn -Dfindbugs.enable=true clean install
