### PR TITLE
Checkstylefix

### DIFF
--- a/build/src/main/resources/checkstyle/checkstyle.xml
+++ b/build/src/main/resources/checkstyle/checkstyle.xml
@@ -180,7 +180,7 @@
 
         <!-- Checks for class design                         -->
         <!-- See http://checkstyle.sf.net/config_design.html -->
-        <module name="DesignForExtension"/>
+        <!--<module name="DesignForExtension"/>-->
         <module name="FinalClass"/>
         <module name="HideUtilityClassConstructor"/>
         <module name="InterfaceIsType"/>
@@ -190,7 +190,7 @@
         <!-- Miscellaneous other checks.                   -->
         <!-- See http://checkstyle.sf.net/config_misc.html -->
         <module name="ArrayTypeStyle"/>
-        <module name="FinalParameters"/>
+        <!--<module name="FinalParameters"/>-->
         <module name="TodoComment"/>
         <module name="UpperEll"/>
 

--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,20 @@
 	
 	<build>
 		<plugins>
+		    <plugin>
+		        <groupId>org.codehaus.mojo</groupId>
+                <artifactId>dashboard-maven-plugin</artifactId>
+                <version>1.0.0-beta-1</version>
+                <executions>
+                    <execution>
+                        <id>aggregate-dashboard</id>
+                        <phase>site</phase>
+                        <goals>
+                            <goal>dashboard</goal>
+                        </goals>
+                    </execution>
+                </executions>
+		    </plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
@@ -141,26 +155,6 @@
 					</execution>
 				</executions>
 			</plugin>
-			<plugin>
-				<artifactId>maven-checkstyle-plugin</artifactId>
-				<version>2.6</version>
-				<dependencies>
-					<dependency>
-						<groupId>org.switchyard</groupId>
-						<artifactId>core-build</artifactId>
-						<version>${project.version}</version>
-					</dependency>
-				</dependencies>
-				<executions>
-					<execution>
-						<id>check-style</id>
-						<phase>site</phase>
-						<goals>
-							<goal>checkstyle</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
 		</plugins>
 	</build>
 	<repositories>
@@ -193,6 +187,55 @@
 	</pluginRepositories>
     <profiles>
         <profile>
+            <id>checkstyle</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+                <property>
+                    <name>org.switchyard.checkstyle.enable</name>
+                    <value>true</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-checkstyle-plugin</artifactId>
+                        <version>2.6</version>
+                        <dependencies>
+                            <dependency>
+                                <groupId>org.switchyard</groupId>
+                                <artifactId>core-build</artifactId>
+                                <version>${project.version}</version>
+                            </dependency>
+                        </dependencies>
+                        <executions>
+                            <execution>
+                                <id>check-style</id>
+                                <phase>site</phase>
+                                <goals> 
+                                <goal>checkstyle</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>            
+            </build>
+            <reporting>
+            <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <version>2.6</version>
+                <configuration>
+                    <configLocation>checkstyle/checkstyle.xml</configLocation>
+                    <consoleOutput>false</consoleOutput>
+                    <failsOnError>false</failsOnError>
+                    <useFile/>
+                </configuration>
+            </plugin>
+            </plugins>
+            </reporting>
+        </profile>
+        <profile>
             <id>findbugs</id>
             <activation>
                 <activeByDefault>false</activeByDefault>
@@ -203,40 +246,39 @@
             </activation>
             <build>
                 <plugins>
-            	    <plugin>
-	            	    <groupId>org.codehaus.mojo</groupId>
-			            <artifactId>findbugs-maven-plugin</artifactId>
-		            	<version>2.3.1</version>
-				        <configuration>
-					        <effort>Max</effort>
-					        <threshold>Default</threshold>
-					        <xmlOutput>true</xmlOutput>
-                        </configuration>
-			            <executions>
-	            		    <execution>
-				                <id>find-bugs</id>
-				            	<goals>
-			            		    <goal>findbugs</goal>
-						        </goals>
-					            <phase>verify</phase>
-		            		</execution>    
-            			</executions>
-			        </plugin>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>findbugs-maven-plugin</artifactId>
+                        <version>2.3.2-SNAPSHOT</version>
+                        <executions>
+                            <execution>
+                                <id>find-bugs</id>
+                                <goals>
+                                    <goal>findbugs</goal>
+                                </goals>
+                                <phase>verify</phase>
+                            </execution>    
+                        </executions>
+                    </plugin>
                 </plugins>
-            </build>
+            </build>            
             <reporting>
                 <plugins>
 		            <plugin>
 				        <groupId>org.codehaus.mojo</groupId>
 				        <artifactId>findbugs-maven-plugin</artifactId>
-				        <version>2.3.1</version>
+				        <version>2.3.2-SNAPSHOT</version>
+                        
 		            	<configuration>
-				            <effort>Max</effort>
-					        <threshold>Default</threshold>
-				            <xmlOutput>true</xmlOutput>
-				        </configuration>
+                            <outputDirectory>build</outputDirectory>
+                            <findbugsXmlOutput>true</findbugsXmlOutput>
+                            <findbugsXmlWithMessages>true</findbugsXmlWithMessages>
+                            <threshold>Low</threshold>
+                            <effort>Max</effort>
+                            <xmlOutput>true</xmlOutput>
+				        </configuration>				        
 			        </plugin>
-                </plugins>
+                </plugins>            
             </reporting>
         </profile>                
     </profiles>
@@ -251,17 +293,11 @@
 	</dependencies>
 	<reporting>
 		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-checkstyle-plugin</artifactId>
-				<version>2.6</version>
-				<configuration>
-					<configLocation>checkstyle/checkstyle.xml</configLocation>
-					<consoleOutput>false</consoleOutput>
-					<failsOnError>false</failsOnError>
-					<useFile/>
-				</configuration>
-			</plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>dashboard-maven-plugin</artifactId>
+                <version>1.0.0-beta-1</version>
+            </plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-report-plugin</artifactId>


### PR DESCRIPTION
Omit two somewhat spammy checkstyle modules, profile-ize checkstyle, upgrade our use of findbugs maven plugin to 2.3.2-plugin to avoid a NPE-crasher in 2.3.1, and add the dashboard plugin into our reporting tied to the site phase.
