### PR TITLE
Switchyard 20

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -141,20 +141,6 @@
 					<downloadJavadocs>false</downloadJavadocs>
 				</configuration>
 			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>2.7</version>
-				<executions>
-					<execution>
-						<id>aggregate</id>
-						<goals>
-							<goal>aggregate</goal>
-						</goals>
-						<phase>site</phase>
-					</execution>
-				</executions>
-			</plugin>
 		</plugins>
 	</build>
 	<repositories>
@@ -282,6 +268,166 @@
                 </plugins>            
             </reporting>
         </profile>                
+		<profile>
+			<id>javadoc-uml</id>
+			<activation>
+				<activeByDefault>false</activeByDefault>
+				<property>
+					<name>javadoc.uml</name>
+				</property>
+			</activation>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-javadoc-plugin</artifactId>
+						<version>2.7</version>
+						<executions>
+							<execution>
+								<id>aggregate</id>
+								<goals>
+									<goal>aggregate</goal>
+								</goals>
+								<phase>site</phase>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+			<reporting>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-javadoc-plugin</artifactId>
+						<version>2.7</version>
+						<configuration>
+							<doclet>org.jboss.apiviz.APIviz</doclet>
+							<docletArtifact>
+								<groupId>org.jboss.apiviz</groupId>
+								<artifactId>apiviz</artifactId>
+								<version>1.3.1.GA</version>
+							</docletArtifact>
+							<charset>${project.build.sourceEncoding}</charset>
+							<encoding>${project.build.sourceEncoding}</encoding>
+							<docencoding>${project.build.sourceEncoding}</docencoding>
+							<breakiterator>true</breakiterator>
+							<keywords>true</keywords>
+							<linksource>true</linksource>
+							<quiet>true</quiet>
+							<doctitle>Switchyard ${project.version}</doctitle>
+							<groups>
+								<group>
+									<title>Core API</title>
+									<packages>org.switchyard*</packages>
+								</group>
+								<group>
+									<title>Core Runtime</title>
+									<packages>org.switchyard.internal*</packages>
+								</group>
+								<group>
+									<title>Components</title>
+									<packages>org.switchyard.component*</packages>
+								</group>
+							</groups>
+							<links>
+								<link>http://download.oracle.com/javase/6/docs/api/</link>
+							</links>
+						</configuration>
+						<reportSets>
+							<reportSet>
+								<id>non-aggregate</id>
+								<reports>
+									<report>javadoc</report>
+								</reports>
+							</reportSet>
+							<reportSet>
+								<id>aggregate</id>
+								<reports>
+									<report>aggregate</report>
+								</reports>
+							</reportSet>
+						</reportSets>
+					</plugin>
+				</plugins>
+			</reporting>
+		</profile>
+		<profile>
+			<id>javadoc-nouml</id>
+			<activation>
+				<activeByDefault>false</activeByDefault>
+				<property>
+					<name>!javadoc.uml</name>
+				</property>
+			</activation>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-javadoc-plugin</artifactId>
+						<version>2.7</version>
+						<executions>
+							<execution>
+								<id>aggregate</id>
+								<goals>
+									<goal>aggregate</goal>
+								</goals>
+								<phase>site</phase>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+			<reporting>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-javadoc-plugin</artifactId>
+						<version>2.7</version>
+						<configuration>
+							<charset>${project.build.sourceEncoding}</charset>
+							<encoding>${project.build.sourceEncoding}</encoding>
+							<docencoding>${project.build.sourceEncoding}</docencoding>
+							<breakiterator>true</breakiterator>
+							<keywords>true</keywords>
+							<linksource>true</linksource>
+							<quiet>true</quiet>
+							<doctitle>Switchyard ${project.version}</doctitle>
+							<groups>
+								<group>
+									<title>Core API</title>
+									<packages>org.switchyard*</packages>
+								</group>
+								<group>
+									<title>Core Runtime</title>
+									<packages>org.switchyard.internal*</packages>
+								</group>
+								<group>
+									<title>Components</title>
+									<packages>org.switchyard.component*</packages>
+								</group>
+							</groups>
+							<links>
+								<link>http://download.oracle.com/javase/6/docs/api/</link>
+							</links>
+						</configuration>
+						<reportSets>
+							<reportSet>
+								<id>non-aggregate</id>
+								<reports>
+									<report>javadoc</report>
+								</reports>
+							</reportSet>
+							<reportSet>
+								<id>aggregate</id>
+								<reports>
+									<report>aggregate</report>
+								</reports>
+							</reportSet>
+						</reportSets>
+					</plugin>
+				</plugins>
+			</reporting>
+		</profile>
     </profiles>
 	<dependencies>
 		<dependency>
@@ -306,76 +452,6 @@
 				<configuration>
 					<aggregate>true</aggregate>
 				</configuration>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>2.7</version>
-				<configuration>
-					<!-- http://code.google.com/p/apiviz/ -->
-					<doclet>org.jboss.apiviz.APIviz</doclet>
-					<docletArtifact>
-						<groupId>org.jboss.apiviz</groupId>
-						<artifactId>apiviz</artifactId>
-						<version>1.3.1.GA</version>
-					</docletArtifact>
-					<useStandardDocletOptions>true</useStandardDocletOptions>
-					<charset>${project.build.sourceEncoding}</charset>
-					<encoding>${project.build.sourceEncoding}</encoding>
-					<docencoding>${project.build.sourceEncoding}</docencoding>
-					<breakiterator>true</breakiterator>
-					<version>true</version>
-					<author>true</author>
-					<keywords>true</keywords>
-					<linksource>true</linksource>
-					<quiet>true</quiet>
-					<show>public</show>
-					<!--
-					<stylesheet>maven</stylesheet>
-					-->
-					<!--
-					<excludePackageNames>org.switchyard.foo*:org.switchyard.bar*</excludePackageNames>
-					-->
-					<doctitle>Switchyard ${project.version}</doctitle>
-					<groups>
-						<group>
-							<title>Switchyard: Core</title>
-							<packages>org.switchyard*</packages>
-						</group>
-						<group>
-							<title>Switchyard: Components / File</title>
-							<packages>org.switchyard.components.file*</packages>
-						</group>
-					</groups>
-					<links>
-						<link>http://download.oracle.com/javase/6/docs/api/</link>
-					</links>
-					<!--
-					<additionalparam>
-						-sourceclasspath ${project.build.outputDirectory}
-					</additionalparam>
-					-->
-				</configuration>
-				<reportSets>
-					<reportSet>
-						<id>non-aggregate</id>
-						<reports>
-							<report>javadoc</report>
-							<!--
-							<report>test-javadoc</report>
-							-->
-						</reports>
-					</reportSet>
-					<reportSet>
-						<id>aggregate</id>
-						<reports>
-							<report>aggregate</report>
-							<!--
-							<report>test-aggregate</report>
-							-->
-						</reports>
-					</reportSet>
-				</reportSets>
 			</plugin>
 		</plugins>
 	</reporting>


### PR DESCRIPTION
Fix for https://issues.jboss.org/browse/SWITCHYARD-20 .
The default build will now generate vanilla javadocs.
If you want UML in your javadocs, you have to:
1) Install graphviz: http://www.graphviz.org/Download.php
2) Pass -Djavadoc.uml to your mvn command.
If you do #2 without #1, you will get a WARNING, but it will fall back to vanilla javadocs.
