### PR TITLE
SWITCHYARD-92

### DIFF
--- a/build/src/main/resources/checkstyle/checkstyle.xml
+++ b/build/src/main/resources/checkstyle/checkstyle.xml
@@ -38,6 +38,13 @@
 
         <property name="basedir" value="${basedir}"/>
     -->
+
+<!--
+    <module name="SuppressionFilter">
+         <property name="file" value="suppressions.xml"/>
+    </module>
+-->
+
     <!-- Checks that each Java package has a Javadoc file used for commenting. -->
     <!-- See http://checkstyle.sf.net/config_javadoc.html#JavadocPackage       
     <module name="JavadocPackage">
@@ -152,7 +159,7 @@
         <module name="NoWhitespaceBefore"/>
         <module name="OperatorWrap"/>
         <module name="ParenPad"/>
-        <module name="TypecastParenPad"/>
+        <!--<module name="TypecastParenPad"/>-->
         <module name="WhitespaceAfter">
             <property name="tokens" value="SEMI"/>
         </module>
@@ -164,7 +171,7 @@
 
         <!-- Modifier Checks                                    -->
         <!-- See http://checkstyle.sf.net/config_modifiers.html -->
-        <module name="ModifierOrder"/>
+        <!--<module name="ModifierOrder"/>-->
         <!--<module name="RedundantModifier"/>-->
 
 
@@ -205,7 +212,7 @@
         <!-- See http://checkstyle.sf.net/config_misc.html -->
         <module name="ArrayTypeStyle"/>
         <!--<module name="FinalParameters"/>-->
-        <module name="TodoComment"/>
+        <!--<module name="TodoComment"/>-->
         <module name="UpperEll"/>
 
     </module>

--- a/build/src/main/resources/checkstyle/suppressions.xml
+++ b/build/src/main/resources/checkstyle/suppressions.xml
@@ -5,4 +5,11 @@
     "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
 
 <suppressions>
+
+    <!-- ConfiguratorMojo.java has maven-style annotations in it which 
+	aren't real annotations, but javadoc, which checkstyle chokes on.  
+        Excusing ConfiguratorMojo.java from the checks to avoid checkstyle
+        choking and throwing an Exception -->	
+    <suppress checks="[a-zA-Z0-9]*"
+	files="org/switchyard/tools/maven/plugins/switchyard/ConfiguratorMojo.java"/>
 </suppressions>


### PR DESCRIPTION
SWITCHYARD-92
https://issues.jboss.org/browse/SWITCHYARD-92
Add a suppression for ConfiguratorMojo and remove the TodoComment, ModifierOrder, and TypecastParenPad rules.      The other rules discussed in http://community.jboss.org/thread/162073?tstart=0 already appear to be removed.
