### PR TITLE
SWITCHYARD-108: ExchangeImpl throws a NPE if an attempt is made to send a Fault message on an Exchange where no _outputEndpoint is defined

### DIFF
--- a/runtime/src/test/java/org/switchyard/internal/DomainImplTest.java
+++ b/runtime/src/test/java/org/switchyard/internal/DomainImplTest.java
@@ -58,7 +58,7 @@ public class DomainImplTest {
     public void testCreateExchange() {
         Exchange inOnly = _domain.createExchange(_service, ExchangeContract.IN_ONLY);
         Assert.assertEquals(ExchangePattern.IN_ONLY, inOnly.getContract().getServiceOperation().getExchangePattern());
-        Exchange inOut = _domain.createExchange(_service, ExchangeContract.IN_OUT);
+        Exchange inOut = _domain.createExchange(_service, ExchangeContract.IN_OUT, new MockHandler());
         Assert.assertEquals(ExchangePattern.IN_OUT, inOut.getContract().getServiceOperation().getExchangePattern());
     }
     


### PR DESCRIPTION
https://issues.jboss.org/browse/SWITCHYARD-108
