### PR TITLE
SWITCHYARD-145

### DIFF
--- a/config/src/main/java/org/switchyard/config/model/composite/v1/V1ComponentReferenceInterfaceModel.java
+++ b/config/src/main/java/org/switchyard/config/model/composite/v1/V1ComponentReferenceInterfaceModel.java
@@ -40,6 +40,15 @@ public class V1ComponentReferenceInterfaceModel extends V1BaseInterfaceModel imp
     }
 
     /**
+     * Constructs a new V1ComponentReferenceInterfaceModel of the specified "type", and in the specified namespace.
+     * @param type the "type" of V1ComponentReferenceInterfaceModel
+     * @param namespace the namespace
+     */
+    public V1ComponentReferenceInterfaceModel(String type, String namespace) {
+        super(type, namespace);
+    }
+
+    /**
      * Constructs a new V1ComponentReferenceInterfaceModel with the specified Configuration and Descriptor.
      * @param config the Configuration
      * @param desc the Descriptor

--- a/tools/maven/archetypes/application/src/main/resources/archetype-resources/pom.xml
+++ b/tools/maven/archetypes/application/src/main/resources/archetype-resources/pom.xml
@@ -68,7 +68,7 @@
           <executions>
             <execution>
                 <goals>
-                    <goal>configurator</goal>
+                    <goal>configure</goal>
                 </goals>
             </execution>
           </executions>

--- a/tools/maven/plugins/switchyard/src/main/java/org/switchyard/tools/maven/plugins/switchyard/ConfigureMojo.java
+++ b/tools/maven/plugins/switchyard/src/main/java/org/switchyard/tools/maven/plugins/switchyard/ConfigureMojo.java
@@ -45,15 +45,17 @@ import org.switchyard.config.model.switchyard.v1.V1SwitchYardModel;
 import org.switchyard.config.util.Classes;
 
 /**
- * ConfiguratorMojo.
+ * Maven mojo for configuring SwitchYard.
  *
- * @goal configurator
+ * @param <M> the Model type being configured
+ *
+ * @goal configure
  * @phase process-classes
  * @requiresDependencyResolution compile
  *
  * @author David Ward &lt;<a href="mailto:dward@jboss.org">dward@jboss.org</a>&gt; (C) 2011 Red Hat Inc.
  */
-public class ConfiguratorMojo<M extends Model> extends AbstractMojo {
+public class ConfigureMojo<M extends Model> extends AbstractMojo {
 
     /**
      * @parameter
@@ -114,7 +116,7 @@ public class ConfiguratorMojo<M extends Model> extends AbstractMojo {
         }
         ClassLoader loader = AccessController.doPrivileged(new PrivilegedAction<URLClassLoader>() {
             public URLClassLoader run() {
-                return new URLClassLoader(mojoURLs.toArray(new URL[mojoURLs.size()]), ConfiguratorMojo.class.getClassLoader());
+                return new URLClassLoader(mojoURLs.toArray(new URL[mojoURLs.size()]), ConfigureMojo.class.getClassLoader());
             }
         });
         ClassLoader previous = Classes.setTCCL(loader);


### PR DESCRIPTION
config merge uses project artifactId for composite name instead of inheriting the name in user's config
