### PR TITLE
SWITCHYARD-83 Eliminate separate contexts for exchange, message, etc.

### DIFF
--- a/api/src/main/java/org/switchyard/Context.java
+++ b/api/src/main/java/org/switchyard/Context.java
@@ -19,54 +19,106 @@
 
 package org.switchyard;
 
-import java.util.Map;
+import java.util.Set;
 
 /**
  * Holds contextual information around the exchange of messages between a
- * service consumer and provider.  There is a distinct {@code Context} instance
- * for each context {@link Scope}.
+ * service consumer and provider.
  */
 public interface Context {
 
     /**
-     * Retrieves the value of the named property within this context.
+     * Retrieves the named property within this context, regardless
+     * of the scope.
      * @param name property name
      * @return value of the property in this context or null if the property
      * does not exist
      */
-    Object getProperty(String name);
-
+    Property getProperty(String name);
+    
     /**
-     * Returns a map containing all properties in this context. The returned
-     * map is a shallow copy of the property set in this context, so
+     * Retrieves the value of the named property with the given scope in this
+     * context.
+     * @param name property name
+     * @param scope property scope
+     * @return value of the property in this context or null if the property
+     * does not exist
+     */
+    Property getProperty(String name, Scope scope);
+    
+    /**
+     * Retrieves the value of the named property within this context, regardless
+     * of the scope.  This is a convenience method equivalent to 
+     * <code> getProperty(name).getValue() </code>.
+     * @param name property name
+     * @return value of the property in this context or null if the property
+     * does not exist
+     */
+    Object getPropertyValue(String name);
+    
+    /**
+     * Returns the set of all properties in this context. The returned
+     * set is a shallow copy of the properties set in this context, so
      * modifications to the map are not reflected in the underlying context.
-     * @return map containing all properties in this context.  If there are no
-     * properties in this context, an empty map is returned.
+     * @return set containing all properties in this context.  If there are no
+     * properties in this context, an empty set is returned.
      */
-    Map<String, Object> getProperties();
-
+    Set<Property> getProperties();
+    
     /**
-     * Test for whether the named property is present in this context.
-     * @param name name of the context property
-     * @return true if the property exists, false otherwise
+     * Returns the set of all properties in this context in the specified scope. The 
+     * returned set is a shallow copy of the properties set in this context, so
+     * modifications to the map are not reflected in the underlying context.
+     * @param scope scope from which properties will be retrieved
+     * @return set containing all properties in this context for the specified
+     * scope.  If there are no properties in the scope, an empty set is returned.
      */
-    boolean hasProperty(String name);
+    Set<Property> getProperties(Scope scope);
 
     /**
      * Removes the named property from this context.
-     * @param name name of the property to remove
-     * @return the value of the removed property or null if the property did
+     * @param property property to remove
      * not exist
      */
-    Object removeProperty(String name);
+    void removeProperty(Property property);
+    
+    /**
+     * Removes all properties from this context.
+     */
+    void removeProperties();
+    
+    /**
+     * Removes properties from the specified scope from this context.
+     * @param scope scope of the properties to remove
+     */
+    void removeProperties(Scope scope);
 
     /**
      * Sets the named context property with the specified value.  If the context
      * property does not exist already, it is added.  If the property already
-     * exists, the value of the property is replaced.  If the specified value
-     * is null, the property is removed from the context.
+     * exists, the value of the property is replaced. 
      * @param name name of the property to set
      * @param val the value to set for the property
+     * @return a reference to the updated Context
      */
-    void setProperty(String name, Object val);
+    Context setProperty(String name, Object val);
+    
+    /**
+     * Sets the named context property with the specified value in a specific
+     * scope.  If the context property does not exist already, it is added.  
+     * If the property already exists, the value of the property is replaced.  
+     * If the specified value is null, the property is removed from the context.
+     * @param name name of the property to set
+     * @param val the value to set for the property
+     * @param scope scope of the property to add
+     * @return a reference to the updated Context
+     */
+    Context setProperty(String name, Object val, Scope scope);
+    
+    /**
+     * Adds the set of properties to this context.
+     * @param properties set of properties to add
+     * @return a reference to the udpated Context
+     */
+    Context setProperties(Set<Property> properties);
 }

--- a/api/src/main/java/org/switchyard/Exchange.java
+++ b/api/src/main/java/org/switchyard/Exchange.java
@@ -20,6 +20,8 @@
 package org.switchyard;
 
 
+import javax.xml.namespace.QName;
+
 import org.switchyard.metadata.ExchangeContract;
 
 /**
@@ -33,29 +35,31 @@ import org.switchyard.metadata.ExchangeContract;
 public interface Exchange {
 
     /**
+     * Context property name used for Message ID.
+     */
+    String MESSAGE_ID = "org.switchyard.messageId";
+    /**
+     * Context property name used for Relates To.
+     */
+    String RELATES_TO = "org.switchyard.relatesTo";
+
+    /**
      * Retrieves the exchange context.
      * @return the exchange context
      */
     Context getContext();
 
     /**
-     * The unique identifier for this Exchange instance.  The exchange
-     * id can be used to correlate message and fault activity within a message
-     * exchange.  This value is assigned at Exchange creation time and never
-     * changes over the lifetime of the exchange.
-     * @return exchange id as a string.
-     */
-    String getId();
-    /**
      * Get the contract associated with this exchange.
      * @return The exchange contract.
      */
     ExchangeContract getContract();
+    
     /**
      * The service being invoked by this exchange.
      * @return Service to be invoked
      */
-    ServiceReference getService();
+    QName getServiceName();
 
     /**
      * Returns the current message for the exchange.  On new exchanges, this

--- a/api/src/main/java/org/switchyard/Message.java
+++ b/api/src/main/java/org/switchyard/Message.java
@@ -45,12 +45,6 @@ import javax.activation.DataSource;
  * </ul>
  */
 public interface Message {
-
-    /**
-     * Retrieves the message context.
-     * @return the exchange context
-     */
-    Context getContext();
     
     /**
      * Assigns the specified content to the body of this message.

--- a/api/src/main/java/org/switchyard/Property.java
+++ b/api/src/main/java/org/switchyard/Property.java
@@ -1,0 +1,43 @@
+package org.switchyard;
+/* 
+ * JBoss, Home of Professional Open Source 
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved. 
+ * See the copyright.txt in the distribution for a 
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use, 
+ * modify, copy, or redistribute it subject to the terms and conditions 
+ * of the GNU Lesser General Public License, v. 2.1. 
+ * This program is distributed in the hope that it will be useful, but WITHOUT A 
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details. 
+ * You should have received a copy of the GNU Lesser General Public License, 
+ * v.2.1 along with this distribution; if not, write to the Free Software 
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, 
+ * MA  02110-1301, USA.
+ */
+
+/**
+ * Represents a context property consisting of a name, scope, and value.
+ */
+public interface Property {
+
+    /**
+     * The scope of the property.
+     * @return property scope
+     */
+    Scope getScope();
+    
+    /**
+     * The name of the property.
+     * @return property name
+     */
+    String getName();
+    
+    /**
+     * The value of the property.
+     * @return property value
+     */
+    Object getValue();
+}

--- a/api/src/main/java/org/switchyard/Scope.java
+++ b/api/src/main/java/org/switchyard/Scope.java
@@ -1,0 +1,53 @@
+/* 
+ * JBoss, Home of Professional Open Source 
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved. 
+ * See the copyright.txt in the distribution for a 
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use, 
+ * modify, copy, or redistribute it subject to the terms and conditions 
+ * of the GNU Lesser General Public License, v. 2.1. 
+ * This program is distributed in the hope that it will be useful, but WITHOUT A 
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details. 
+ * You should have received a copy of the GNU Lesser General Public License, 
+ * v.2.1 along with this distribution; if not, write to the Free Software 
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, 
+ * MA  02110-1301, USA.
+ */
+
+package org.switchyard;
+
+/**
+ * Defines the scope of a context property.
+ */
+public enum Scope {
+    /** 
+     * Properties available for the duration of an exchange.
+     */
+    EXCHANGE,
+    /**
+     * Properties available during the IN phase of an exchange.
+     */
+    IN,
+    /**
+     * Properties available during the OUT phase of an exchange.
+     */
+    OUT;
+    
+    /**
+     * Returns the active scope for an exchange based on the exchange phase.
+     * @param exchange the exchange used to determine active scope
+     * @return current scope for the exchange
+     */
+    public static Scope activeScope(Exchange exchange) {
+        if (ExchangePhase.IN.equals(exchange.getPhase())) {
+            return Scope.IN;
+        } else if (ExchangePhase.OUT.equals(exchange.getPhase())) {
+            return Scope.OUT;
+        } else {
+            return null;
+        }
+    }
+}

--- a/api/src/main/java/org/switchyard/transform/TransformSequence.java
+++ b/api/src/main/java/org/switchyard/transform/TransformSequence.java
@@ -26,9 +26,10 @@ import java.util.List;
 import javax.xml.namespace.QName;
 
 import org.apache.log4j.Logger;
-import org.switchyard.Context;
 import org.switchyard.Exchange;
 import org.switchyard.Message;
+import org.switchyard.Property;
+import org.switchyard.Scope;
 
 /**
  * Transformation sequence/pipeline.
@@ -65,11 +66,12 @@ public final class TransformSequence implements Serializable {
 
     /**
      * Associate this instance with the supplied message context.
-     *
-     * @param msgCtx The message context. NB: Will be the Exchange once the "zap on send" issue is resolved.
+     * @param exchange associate the transform to this exchange
+     * @param scope associate the transform with this scope
      */
-    public void associateWith(Context msgCtx) {
-        msgCtx.setProperty(TransformSequence.class.getName(), this);
+    public void associateWith(Exchange exchange, Scope scope) {
+        exchange.getContext().setProperty(
+                TransformSequence.class.getName(), this, scope);
     }
 
     /**
@@ -133,7 +135,7 @@ public final class TransformSequence implements Serializable {
      *         no TransformSequence is set on the exchange.
      */
     public static QName getCurrentMessageType(final Exchange exchange) {
-        TransformSequence transformSequence = get(exchange.getMessage());
+        TransformSequence transformSequence = get(exchange);
 
         if (transformSequence != null && !transformSequence._sequence.isEmpty()) {
             return transformSequence._sequence.get(0);
@@ -150,7 +152,7 @@ public final class TransformSequence implements Serializable {
      *         no TransformSequence is set on the exchange.
      */
     public static QName getTargetMessageType(final Exchange exchange) {
-        TransformSequence transformSequence = get(exchange.getMessage());
+        TransformSequence transformSequence = get(exchange);
 
         if (transformSequence != null && !transformSequence._sequence.isEmpty()) {
             // Return the last entry in the sequence...
@@ -187,7 +189,7 @@ public final class TransformSequence implements Serializable {
      */
     public static void applySequence(final Exchange exchange, final TransformerRegistry registry) {
         Message message = exchange.getMessage();
-        TransformSequence transformSequence = get(message);
+        TransformSequence transformSequence = get(exchange);
 
         if (transformSequence == null) {
             return;
@@ -203,12 +205,12 @@ public final class TransformSequence implements Serializable {
         _sequence.add(typeName);
     }
 
-    private static TransformSequence get(final Message message) {
-        if (message == null) {
+    private static TransformSequence get(final Exchange exchange) {
+        Property sequenceProperty = exchange.getContext().getProperty(TransformSequence.class.getName(), Scope.activeScope(exchange));
+        if (sequenceProperty != null) {
+            return (TransformSequence)sequenceProperty.getValue();
+        } else {
             return null;
         }
-
-        Context context = message.getContext();
-        return (TransformSequence) context.getProperty(TransformSequence.class.getName());
     }
 }

--- a/api/src/test/java/org/switchyard/MockExchange.java
+++ b/api/src/test/java/org/switchyard/MockExchange.java
@@ -1,0 +1,115 @@
+/* 
+ * JBoss, Home of Professional Open Source 
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved. 
+ * See the copyright.txt in the distribution for a 
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use, 
+ * modify, copy, or redistribute it subject to the terms and conditions 
+ * of the GNU Lesser General Public License, v. 2.1. 
+ * This program is distributed in the hope that it will be useful, but WITHOUT A 
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details. 
+ * You should have received a copy of the GNU Lesser General Public License, 
+ * v.2.1 along with this distribution; if not, write to the Free Software 
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, 
+ * MA  02110-1301, USA.
+ */
+
+package org.switchyard;
+
+import javax.xml.namespace.QName;
+
+import org.switchyard.metadata.ExchangeContract;
+
+/**
+ * Dumb implementation of Exchange meant for unit testing. 
+ */
+public class MockExchange implements Exchange {
+    
+    private ExchangeState _state;
+    private ExchangePhase _phase;
+    private QName _serviceName;
+    private ExchangeContract _contract;
+    private Message _message;
+    private Context _context;
+    
+    public MockExchange() {
+    }
+
+    @Override
+    public Message createMessage() {
+        return _message;
+    }
+
+    @Override
+    public Context getContext() {
+        return _context;
+    }
+
+    @Override
+    public ExchangeContract getContract() {
+        return _contract;
+    }
+
+    @Override
+    public Message getMessage() {
+        return _message;
+    }
+
+    @Override
+    public ExchangePhase getPhase() {
+        return _phase;
+    }
+
+    @Override
+    public QName getServiceName() {
+        return _serviceName;
+    }
+
+    @Override
+    public ExchangeState getState() {
+        return _state;
+    }
+
+    @Override
+    public void send(Message message) {
+        // NOP
+    }
+
+    @Override
+    public void sendFault(Message message) {
+        // NOP
+    }
+
+    public MockExchange setPhase(ExchangePhase phase) {
+        _phase = phase;
+        return this;
+    }
+    
+    public MockExchange setState(ExchangeState state) {
+        _state = state;
+        return this;
+    }
+    
+    public MockExchange setServiceName(QName serviceName) {
+        _serviceName = serviceName;
+        return this;
+    }
+    
+    public MockExchange setMessage(Message message) {
+        _message = message;
+        return this;
+    }
+    
+    public MockExchange setContext(Context context) {
+        _context = context;
+        return this;
+    }
+    
+    public MockExchange setContract(ExchangeContract contract) {
+        _contract = contract;
+        return this;
+    }
+}

--- a/api/src/test/java/org/switchyard/ScopeTest.java
+++ b/api/src/test/java/org/switchyard/ScopeTest.java
@@ -1,0 +1,48 @@
+/* 
+ * JBoss, Home of Professional Open Source 
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved. 
+ * See the copyright.txt in the distribution for a 
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use, 
+ * modify, copy, or redistribute it subject to the terms and conditions 
+ * of the GNU Lesser General Public License, v. 2.1. 
+ * This program is distributed in the hope that it will be useful, but WITHOUT A 
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details. 
+ * You should have received a copy of the GNU Lesser General Public License, 
+ * v.2.1 along with this distribution; if not, write to the Free Software 
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, 
+ * MA  02110-1301, USA.
+ */
+
+package org.switchyard;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ScopeTest {
+
+    @Test
+    public void testActiveScopeIn() {
+        MockExchange exchange = new MockExchange().setPhase(ExchangePhase.IN);
+        Scope scope = Scope.activeScope(exchange);
+        Assert.assertEquals(Scope.IN, scope);
+    }
+    
+    @Test
+    public void testActiveScopeOut() {
+        MockExchange exchange = new MockExchange().setPhase(ExchangePhase.OUT);
+        Scope scope = Scope.activeScope(exchange);
+        Assert.assertEquals(Scope.OUT, scope);
+    }
+    
+    @Test
+    public void testActiveScopeNullPhaseNoException() {
+        MockExchange exchange = new MockExchange();
+        Scope scope = Scope.activeScope(exchange);
+        // above should not throw an exception, returned scope should be null
+        Assert.assertNull(scope);
+    }
+}

--- a/bus/hornetq/pom.xml
+++ b/bus/hornetq/pom.xml
@@ -26,7 +26,7 @@
         <groupId>org.switchyard</groupId>
         <artifactId>switchyard-core-parent</artifactId>
         <version>0.1.0-SNAPSHOT</version>
-        <relativePath>../../../pom.xml</relativePath>
+        <relativePath>../../pom.xml</relativePath>
     </parent>
     
     <groupId>org.switchyard</groupId>

--- a/bus/hornetq/src/test/java/org/switchyard/bus/hornetq/HornetQDispatcherTest.java
+++ b/bus/hornetq/src/test/java/org/switchyard/bus/hornetq/HornetQDispatcherTest.java
@@ -34,6 +34,8 @@ import org.junit.Test;
 import org.switchyard.BaseHandler;
 import org.switchyard.Exchange;
 import org.switchyard.HandlerException;
+import org.switchyard.Message;
+import org.switchyard.Scope;
 import org.switchyard.ServiceReference;
 import org.switchyard.handlers.HandlerChain;
 import org.switchyard.internal.DefaultHandlerChain;
@@ -69,11 +71,13 @@ public class HornetQDispatcherTest {
         inHandlers.addLast("in", sink);
         Dispatcher dispatch = _provider.createDispatcher(service, inHandlers, null);
         
-        Exchange exchange = new ExchangeImpl(service, ExchangeContract.IN_ONLY, dispatch, null, null);
+        Exchange exchange = new ExchangeImpl(service.getName(), ExchangeContract.IN_ONLY, dispatch, null, null);
         exchange.send(exchange.createMessage());
         Thread.sleep(200);
         
-        Assert.assertEquals(exchange, sink.getLastExchange());
+        Assert.assertEquals(
+                exchange.getContext().getProperty(Exchange.MESSAGE_ID, Scope.IN), 
+                sink.getLastExchange().getContext().getProperty(Exchange.MESSAGE_ID, Scope.IN));
     }
     
 
@@ -91,12 +95,14 @@ public class HornetQDispatcherTest {
         ExchangeSink outHandler = new ExchangeSink();
         outHandlers.addLast("out", outHandler);
         
-        Exchange exchange = new ExchangeImpl(service, ExchangeContract.IN_OUT, dispatch, null, outHandlers);
+        Exchange exchange = new ExchangeImpl(service.getName(), ExchangeContract.IN_OUT, dispatch, null, outHandlers);
         exchange.send(exchange.createMessage());
         Thread.sleep(400);
         
         Assert.assertNotNull(outHandler.getLastExchange());
-        Assert.assertEquals(exchange, outHandler.getLastExchange());
+        Assert.assertEquals(
+                exchange.getContext().getProperty(Exchange.MESSAGE_ID, Scope.IN).getValue(), 
+                outHandler.getLastExchange().getContext().getProperty(Exchange.RELATES_TO, Scope.OUT).getValue());
     }
     
 }

--- a/runtime/src/main/java/org/switchyard/internal/ContextProperty.java
+++ b/runtime/src/main/java/org/switchyard/internal/ContextProperty.java
@@ -1,0 +1,117 @@
+/* 
+ * JBoss, Home of Professional Open Source 
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved. 
+ * See the copyright.txt in the distribution for a 
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use, 
+ * modify, copy, or redistribute it subject to the terms and conditions 
+ * of the GNU Lesser General Public License, v. 2.1. 
+ * This program is distributed in the hope that it will be useful, but WITHOUT A 
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details. 
+ * You should have received a copy of the GNU Lesser General Public License, 
+ * v.2.1 along with this distribution; if not, write to the Free Software 
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, 
+ * MA  02110-1301, USA.
+ */
+
+package org.switchyard.internal;
+
+import java.io.IOException;
+
+import org.switchyard.Property;
+import org.switchyard.Scope;
+import org.switchyard.internal.ContextProperty.ContextPropertyFactory;
+import org.switchyard.io.Serialization.AccessType;
+import org.switchyard.io.Serialization.Factory;
+import org.switchyard.io.Serialization.Strategy;
+
+/**
+ * Serializable implementation of <code>Context</code>.
+ */
+@Strategy(access=AccessType.FIELD, factory=ContextPropertyFactory.class)
+public class ContextProperty implements Property {
+    
+    private String _name;
+    private Scope _scope;
+    private Object _value;
+    
+    // Private ctor used for internal serialization only
+    private ContextProperty() {
+        
+    }
+    
+    ContextProperty(String name, Scope scope, Object value) {
+        if (name == null || scope == null) {
+            throw new IllegalArgumentException("Property name and scope must not be null!");
+        }
+        
+        _name = name;
+        _scope = scope;
+        _value = value;
+    }
+
+    @Override
+    public String getName() {
+        return _name;
+    }
+
+    @Override
+    public Scope getScope() {
+        return _scope;
+    }
+
+    @Override
+    public Object getValue() {
+        return _value;
+    }
+    
+    /**
+     * Set the value of a context property.
+     * @param value value to set
+     */
+    public void setValue(Object value) {
+        _value = value;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof ContextProperty)) {
+            return false;
+        }
+        
+        ContextProperty comp = (ContextProperty)obj;
+        return _name.equals(comp.getName()) 
+                && _scope.equals(comp.getScope())
+                && (_value == null ? comp.getValue() == null : _value.equals(comp.getValue()));
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 1;
+        hash = hash * 31 + _name.hashCode();
+        hash = hash * 31 + _scope.hashCode();
+        hash = hash * 31 + (_value != null ? _value.hashCode() : 0);
+        return hash;
+    }
+
+    @Override
+    public String toString() {
+        return ("[name=" + _name + ", scope=" + _scope + ", value=" + _value + "]");
+    }
+    
+    /**
+     * The serialization factory for ContextProperty.
+     */
+    public static final class ContextPropertyFactory implements Factory<ContextProperty> {
+        @Override
+        public ContextProperty create(Class<ContextProperty> type) throws IOException {
+            return new ContextProperty();
+        }
+    }
+}

--- a/runtime/src/main/java/org/switchyard/internal/DefaultHandlerChain.java
+++ b/runtime/src/main/java/org/switchyard/internal/DefaultHandlerChain.java
@@ -30,6 +30,7 @@ import org.switchyard.ExchangeHandler;
 import org.switchyard.ExchangeState;
 import org.switchyard.HandlerException;
 import org.switchyard.Message;
+import org.switchyard.Scope;
 import org.switchyard.handlers.HandlerChain;
 import org.switchyard.metadata.ExchangeContract;
 import org.switchyard.metadata.java.JavaService;
@@ -142,7 +143,7 @@ public class DefaultHandlerChain implements HandlerChain {
             TransformSequence.
                 from(exceptionTypeName).
                 to(invokerFaultTypeName).
-                associateWith(faultMessage.getContext());
+                associateWith(exchange, Scope.OUT);
         }
     }
     

--- a/runtime/src/main/java/org/switchyard/internal/DefaultMessage.java
+++ b/runtime/src/main/java/org/switchyard/internal/DefaultMessage.java
@@ -25,7 +25,6 @@ import java.util.Map;
 import javax.activation.DataSource;
 import javax.xml.namespace.QName;
 
-import org.switchyard.Context;
 import org.switchyard.Message;
 import org.switchyard.io.Serialization.AccessType;
 import org.switchyard.io.Serialization.CoverageType;
@@ -36,31 +35,21 @@ import org.switchyard.transform.Transformer;
 import org.switchyard.transform.TransformerRegistry;
 
 /**
- * Default message.
+ * Serializable implementation of <code>Message</code>.
  */
 @Strategy(access=AccessType.FIELD, coverage=CoverageType.INCLUSIVE)
 public class DefaultMessage implements Message {
 
     @Exclude private TransformerRegistry _transformerRegistry;
-    private Context _context;
     private Object _content;
     private Map<String, DataSource> _attachments = 
         new HashMap<String, DataSource>();
     
 
     /**
-     * Create a new instance of DefaultMessage with an empty context.
+     * Create a new instance of DefaultMessage.
      */
     public DefaultMessage() {
-        _context = new DefaultContext();
-    }
-
-    /**
-     * Create a new instance of DefaultMessage with the specified context.
-     * @param context context instance to use with this message
-     */
-    public DefaultMessage(Context context) {
-        _context = context;
     }
 
     /**
@@ -139,10 +128,4 @@ public class DefaultMessage implements Message {
         _content = content;
         return this;
     }
-
-    @Override
-    public Context getContext() {
-        return _context;
-    }
-
 }

--- a/runtime/src/main/java/org/switchyard/internal/DomainImpl.java
+++ b/runtime/src/main/java/org/switchyard/internal/DomainImpl.java
@@ -25,7 +25,6 @@ import javax.xml.namespace.QName;
 
 import org.switchyard.Exchange;
 import org.switchyard.ExchangeHandler;
-import org.switchyard.ExchangePhase;
 import org.switchyard.ServiceDomain;
 import org.switchyard.ServiceReference;
 import org.switchyard.handlers.HandlerChain;
@@ -92,7 +91,8 @@ public class DomainImpl implements ServiceDomain {
         }
 
         // create the exchange
-        ExchangeImpl exchange = new ExchangeImpl(service, contract, dispatcher, _transformerRegistry, replyChain);
+        ExchangeImpl exchange = new ExchangeImpl(service.getName(), contract, 
+                dispatcher, _transformerRegistry, replyChain);
         return exchange;
     }
 
@@ -133,13 +133,5 @@ public class DomainImpl implements ServiceDomain {
     public ServiceReference getService(QName serviceName) {
         List<Service> services = _registry.getServices(serviceName);
         return services.isEmpty() ? null : services.get(0).getReference();
-    }
-    
-    /**
-     * Returns an endpoint name based on the domain name, service name, and 
-     * exchange phase.
-     */
-    private String getEndpointName(QName serviceName, ExchangePhase phase) {
-        return _name + ":" + serviceName + ":" + phase.toString();
     }
 }

--- a/runtime/src/main/java/org/switchyard/internal/ScopedPropertyMap.java
+++ b/runtime/src/main/java/org/switchyard/internal/ScopedPropertyMap.java
@@ -1,0 +1,130 @@
+/* 
+ * JBoss, Home of Professional Open Source 
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved. 
+ * See the copyright.txt in the distribution for a 
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use, 
+ * modify, copy, or redistribute it subject to the terms and conditions 
+ * of the GNU Lesser General Public License, v. 2.1. 
+ * This program is distributed in the hope that it will be useful, but WITHOUT A 
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details. 
+ * You should have received a copy of the GNU Lesser General Public License, 
+ * v.2.1 along with this distribution; if not, write to the Free Software 
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, 
+ * MA  02110-1301, USA.
+ */
+
+package org.switchyard.internal;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.switchyard.Property;
+import org.switchyard.Scope;
+import org.switchyard.io.Serialization.AccessType;
+import org.switchyard.io.Serialization.Strategy;
+
+/**
+ * A simple container for a set of scoped property maps.  Properties that are 
+ * put and get are done stored based on the scope of the property.
+ */
+@Strategy(access=AccessType.FIELD)
+public class ScopedPropertyMap {
+    private Map<Scope, Map<String, Property>> _props = 
+        new HashMap<Scope, Map<String, Property>>();
+    
+    /**
+     * Creates a new ScopedPropertyMap with one property map for each Scope type.
+     */
+    public ScopedPropertyMap() {
+        for (Scope scope : Scope.values()) {
+            _props.put(scope, new HashMap<String, Property>());
+        }
+    }
+    
+    /**
+     * Adds a property to the map.
+     * @param property property to add
+     */
+    public void put(Property property) {
+        _props.get(property.getScope()).put(property.getName(), property);
+    }
+    
+    /**
+     * Gets a property from the map.
+     * @param scope the scope of the property
+     * @param name the name of the property
+     * @return the property stored with the given name at the specified scope, or
+     * null if no such property exists.
+     */
+    public Property get(Scope scope, String name) {
+        return _props.get(scope).get(name);
+    }
+    
+    /**
+     * Get all properties from the specified scope.
+     * @param scope scope to grab properties from
+     * @return set of all properties in the specified scope
+     */
+    public Set<Property> get(Scope scope) {
+        return new HashSet<Property>(_props.get(scope).values());
+    }
+    
+    /**
+     * Get all properties from all scopes.
+     * @return a set of all properties.
+     */
+    public Set<Property> get() {
+        HashSet<Property> allProps = new HashSet<Property>();
+        for (Scope scope : _props.keySet()) {
+            allProps.addAll(get(scope));
+        }
+        return allProps;
+    }
+    
+    /**
+     * Remove the specified property from the map.
+     * @param property property to remove
+     */
+    public void remove(Property property) {
+        _props.get(property.getScope()).remove(property.getName());
+    }
+    
+    /**
+     * Removes all properties in the specified scope.
+     * @param scope scope in which all properties should be removed.
+     */
+    public void clear(Scope scope) {
+        _props.get(scope).clear();
+    }
+
+    /**
+     * Removes all properties in all scopes.
+     */
+    @SuppressWarnings("unchecked")
+    public void clear() {
+        for (Map map : _props.values()) {
+            map.clear();
+        }
+    }
+    
+    /**
+     * Creates a new ScopedPropertyMap and copies references from all property
+     * entries in this map to the new map.
+     * @return new shallow copy of this property map
+     */
+    public ScopedPropertyMap copy() {
+        ScopedPropertyMap props = new ScopedPropertyMap();
+        for (Map<String, Property> scopedMap : _props.values()) {
+            for (Property prop : scopedMap.values()) {
+                props.put(prop);
+            }
+        }
+        return props;
+    }
+}

--- a/runtime/src/test/java/org/switchyard/internal/ContextPropertyTest.java
+++ b/runtime/src/test/java/org/switchyard/internal/ContextPropertyTest.java
@@ -1,0 +1,70 @@
+/* 
+ * JBoss, Home of Professional Open Source 
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved. 
+ * See the copyright.txt in the distribution for a 
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use, 
+ * modify, copy, or redistribute it subject to the terms and conditions 
+ * of the GNU Lesser General Public License, v. 2.1. 
+ * This program is distributed in the hope that it will be useful, but WITHOUT A 
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details. 
+ * You should have received a copy of the GNU Lesser General Public License, 
+ * v.2.1 along with this distribution; if not, write to the Free Software 
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, 
+ * MA  02110-1301, USA.
+ */
+
+package org.switchyard.internal;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.switchyard.Scope;
+
+public class ContextPropertyTest {
+    
+    @Test
+    public void testNullName() {
+        // null name should not be permitted
+        try {
+            new ContextProperty(null, Scope.IN, "bar");
+            Assert.fail("Null property name should not be permitted!");
+        } catch (IllegalArgumentException expected) {
+            // All good
+            return;
+        }
+    }
+    
+    @Test
+    public void testNullScope() {
+        // null scope should not be permitted
+        try {
+            new ContextProperty("foo", null, "bar");
+            Assert.fail("Null property scope should not be permitted!");
+        } catch (IllegalArgumentException expected) {
+            // All good
+            return;
+        }
+    }
+    
+    @Test
+    public void testEquals() {
+        ContextProperty prop1 = new ContextProperty("foo", Scope.IN, "bar");
+        ContextProperty prop2 = new ContextProperty("foo", Scope.IN, "bar");
+        Assert.assertTrue(prop1.equals(prop2));
+    }
+
+    @Test
+    public void testNotEquals() {
+        ContextProperty propRef = new ContextProperty("foo", Scope.IN, "bar");
+        ContextProperty propDiffName = new ContextProperty("oops", Scope.IN, "bar");
+        ContextProperty propDiffScope = new ContextProperty("foo", Scope.OUT, "bar");
+        ContextProperty propDiffValue = new ContextProperty("foo", Scope.IN, "nope");
+        Assert.assertFalse(propRef.equals(propDiffName));
+        Assert.assertFalse(propRef.equals(propDiffScope));
+        Assert.assertFalse(propRef.equals(propDiffValue));
+    }
+    
+}

--- a/runtime/src/test/java/org/switchyard/internal/DefaultContextTest.java
+++ b/runtime/src/test/java/org/switchyard/internal/DefaultContextTest.java
@@ -19,11 +19,13 @@
 
 package org.switchyard.internal;
 
-import java.util.Map;
+import java.util.Set;
 
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.switchyard.Property;
+import org.switchyard.Scope;
 
 /**
  *  Tests for context-related operations.
@@ -35,58 +37,114 @@ public class DefaultContextTest {
     private DefaultContext _context;
     
     @Before
-    public void setUp() throws Exception {
+    public void setUp()  {
         _context = new DefaultContext();
     }
     
     @Test
-    public void testGetSet() throws Exception {
+    public void testGetSet() {
         _context.setProperty(PROP_NAME, PROP_VAL);
-        Assert.assertEquals(PROP_VAL, _context.getProperty(PROP_NAME));
-    }
-
-    @Test
-    public void testHasProperty() throws Exception {
-        Assert.assertFalse(_context.hasProperty(PROP_NAME));
-        _context.setProperty(PROP_NAME, PROP_VAL);
-        Assert.assertTrue(_context.hasProperty(PROP_NAME));
-    }
-
-    @Test
-    public void testRemove() throws Exception {
-        _context.setProperty(PROP_NAME, PROP_VAL);
-        Assert.assertTrue(_context.hasProperty(PROP_NAME));
-        _context.removeProperty(PROP_NAME);
-        Assert.assertFalse(_context.hasProperty(PROP_NAME));
+        Assert.assertEquals(PROP_VAL, _context.getProperty(PROP_NAME).getValue());
     }
     
     @Test
-    public void testRemoveNonexistent() throws Exception {
-        // Removing a nonexistent property should not throw an exception
-        final String propName = "blahFooYech";
-        Assert.assertFalse(_context.hasProperty(propName));
-        _context.removeProperty(propName);
+    public void testGetSetScoped() {
+        _context.setProperty(PROP_NAME, PROP_VAL, Scope.IN);
+        Assert.assertEquals(PROP_VAL, _context.getProperty(PROP_NAME, Scope.IN).getValue());
+        Assert.assertNull(_context.getProperty(PROP_NAME));
+        Assert.assertNull(_context.getProperty(PROP_NAME, Scope.OUT));
     }
     
     @Test
-    public void testNullContextValue() throws Exception {
+    public void testGetPropertyValue() {
+        final String key = "prop";
+        final String value = "exchange";
+        _context.setProperty(key, value);
+        _context.setProperty(key, "in", Scope.IN);
+        _context.setProperty(key, "out", Scope.OUT);
+        Assert.assertEquals(value, _context.getPropertyValue(key));
+    }
+
+    @Test
+    public void testRemove() {
         _context.setProperty(PROP_NAME, PROP_VAL);
-        Assert.assertTrue(_context.hasProperty(PROP_NAME));
-        // setting the value to null should remove the property from context
+        Property p = _context.getProperty(PROP_NAME);
+        Assert.assertEquals(PROP_VAL, p.getValue());
+        _context.removeProperty(p);
+        Assert.assertNull(_context.getProperty(PROP_NAME));
+    }
+    
+    @Test
+    public void testRemoveScopedProperites() {
+        _context.setProperty("out", "bar", Scope.OUT);
+        _context.setProperty("in", "foo", Scope.IN);
+        _context.removeProperties(Scope.IN);
+        Assert.assertNull(_context.getProperty("in", Scope.IN));
+        Assert.assertNotNull(_context.getProperty("out", Scope.OUT));
+    }
+    
+    @Test
+    public void testRemoveProperites() {
+        _context.setProperty("out", "bar", Scope.OUT);
+        _context.setProperty("in", "foo", Scope.IN);
+        _context.setProperty("ex", "psst", Scope.EXCHANGE);
+        _context.removeProperties();
+        Assert.assertNull(_context.getPropertyValue("in"));
+        Assert.assertNull(_context.getPropertyValue("out"));
+        Assert.assertNull(_context.getPropertyValue("ex"));
+    }
+    
+    @Test
+    public void testNullContextValue() {
         _context.setProperty(PROP_NAME, null);
-        Assert.assertFalse(_context.hasProperty(PROP_NAME));
+        Property p = _context.getProperty(PROP_NAME);
+        Assert.assertNotNull(p);
+        Assert.assertNull(p.getValue());
+    }
+    
+    @Test
+    public void testSetPropertySet() {
+        _context.setProperty("one", "bar");
+        _context.setProperty("two", "foo");
+        Set<Property> props = _context.getProperties(Scope.EXCHANGE);
+        DefaultContext ctx = new DefaultContext();
+        ctx.setProperties(props);
+        Assert.assertNotNull(ctx.getPropertyValue("one"));
+        Assert.assertNotNull(ctx.getPropertyValue("two"));
     }
 
     @Test
-    public void testGetProperties() throws Exception {
+    public void testGetProperties() {
         _context.setProperty(PROP_NAME, PROP_VAL);
-        Map<String, Object> props = _context.getProperties();
-        Assert.assertEquals(PROP_VAL, props.get(PROP_NAME));
+        Set<Property> props = _context.getProperties();
+        Assert.assertTrue(props.size() == 1);
+        Assert.assertEquals(PROP_VAL, props.iterator().next().getValue());
         
         // operations to the returned map should *not* be reflected in the context
         props.remove(PROP_NAME);
-        Assert.assertFalse(props.containsKey(PROP_NAME));
-        Assert.assertTrue(_context.hasProperty(PROP_NAME));
+        Assert.assertTrue(_context.getProperties().size() == 1);
+    }
+    
+    @Test
+    public void testCopy() {
+        _context.setProperty("exchange", "val", Scope.EXCHANGE);
+        _context.setProperty("in", "val", Scope.IN);
+        _context.setProperty("out", "val", Scope.OUT);
+        DefaultContext ctx = _context.copy();
+        // verify that all fields were copied
+        Assert.assertEquals(
+                _context.getProperty("exchange", Scope.EXCHANGE),
+                ctx.getProperty("exchange", Scope.EXCHANGE));
+        Assert.assertEquals(
+                _context.getProperty("in", Scope.IN),
+                ctx.getProperty("in", Scope.IN));
+        Assert.assertEquals(
+                _context.getProperty("out", Scope.OUT),
+                ctx.getProperty("out", Scope.OUT));
+        // verify that mods to one context do not impact the other
+        _context.removeProperties(Scope.EXCHANGE);
+        Assert.assertNull(_context.getProperty("exchange", Scope.EXCHANGE));
+        Assert.assertNotNull(ctx.getProperty("exchange", Scope.EXCHANGE));
     }
     
 }

--- a/runtime/src/test/java/org/switchyard/internal/io/ExchangeSerializationTests.java
+++ b/runtime/src/test/java/org/switchyard/internal/io/ExchangeSerializationTests.java
@@ -101,7 +101,6 @@ public class ExchangeSerializationTests {
             msg = new DefaultMessage();
         }
         msg.setContent("content");
-        buildContext((DefaultContext)msg.getContext());
         msg.addAttachment("data", new MockDataSource("mock", "text/plain", "abc123"));
         return msg;
     }
@@ -112,6 +111,7 @@ public class ExchangeSerializationTests {
         ServiceReference service = domain.registerService(new QName("InPhase"), handler);
         ExchangeImpl exchange = (ExchangeImpl)domain.createExchange(service, ExchangeContract.IN_ONLY, handler);
         exchange.getContext().setProperty("baz", "whiz");
+        buildContext((DefaultContext)exchange.getContext());
         DefaultMessage msg = buildMessage((DefaultMessage)exchange.createMessage());
         exchange.send(msg);
         handler.waitForOKMessage();
@@ -119,12 +119,11 @@ public class ExchangeSerializationTests {
     }
 
     private void assertContext(Context ctx) throws Exception {
-        Assert.assertEquals("bar", ctx.getProperty("foo"));
-        Assert.assertEquals("David", ((Car)ctx.getProperty("car")).getDriver().getName());
+        Assert.assertEquals("bar", ctx.getProperty("foo").getValue());
+        Assert.assertEquals("David", ((Car)ctx.getProperty("car").getValue()).getDriver().getName());
     }
 
     private void assertMessage(Message msg) throws Exception {
-        assertContext(msg.getContext());
         Assert.assertEquals("content", msg.getContent());
         InputStream is =  msg.getAttachment("data").getInputStream();
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
@@ -138,11 +137,11 @@ public class ExchangeSerializationTests {
 
     private void assertExchange(Exchange exchange) throws Exception {
         assertMessage(exchange.getMessage());
-        Assert.assertNotNull(exchange.getId());
+        assertContext(exchange.getContext());
         Assert.assertEquals(ExchangeContract.IN_ONLY, exchange.getContract());
         Assert.assertEquals(ExchangePhase.IN, exchange.getPhase());
         Assert.assertEquals(ExchangeState.OK, exchange.getState());
-        Assert.assertEquals("whiz", exchange.getContext().getProperty("baz"));
+        Assert.assertEquals("whiz", exchange.getContext().getProperty("baz").getValue());
     }
 
     private static final class MockDataSource implements DataSource {

--- a/runtime/src/test/java/org/switchyard/tests/TransformationTest.java
+++ b/runtime/src/test/java/org/switchyard/tests/TransformationTest.java
@@ -30,6 +30,7 @@ import org.switchyard.Exchange;
 import org.switchyard.HandlerException;
 import org.switchyard.Message;
 import org.switchyard.MockHandler;
+import org.switchyard.Scope;
 import org.switchyard.ServiceReference;
 import org.switchyard.ServiceDomain;
 import org.switchyard.MockDomain;
@@ -90,11 +91,10 @@ public class TransformationTest {
             // name will not be necessary once the service definition is available
             // at runtime
             Message msg = exchange.createMessage().setContent(input);
-            Context msgCtx = msg.getContext();
             TransformSequence.
                     from(inType).
                     to(expectedDestType).
-                    associateWith(msgCtx);
+                    associateWith(exchange, Scope.IN);
 
             msg.setContent(input);
             exchange.send(msg);
@@ -132,11 +132,10 @@ public class TransformationTest {
         // name will not be necessary once the service definition is available
         // at runtime
         Message msg = exchange.createMessage().setContent(input);
-        Context msgCtx = msg.getContext();
         TransformSequence.
                 from(inType).
                 to(expectedDestType).
-                associateWith(msgCtx);
+                associateWith(exchange, Scope.IN);
 
         msg.setContent(input);
 


### PR DESCRIPTION
Eliminated Context on Message and moved to scoped context on Exchange.  I tried to strike a happy balance here between having a getContext() method attached to everything and doing magic with thread locals in a stand-alone Context object.  The current API will prevent Context from bleeding across exchanges inadvertently, like when you take a message from one exchange and send it with another.

https://issues.jboss.org/browse/SWITCHYARD-83
