### PR TITLE
SWITCHYARD-111 workaround for inability to resolve wsdl20-instance.xsd

### DIFF
--- a/config/src/main/resources/org/oasis-open/docs/ns/opencsa/sca/200912/sca-1.1-cd06.xsd
+++ b/config/src/main/resources/org/oasis-open/docs/ns/opencsa/sca/200912/sca-1.1-cd06.xsd
@@ -19,7 +19,9 @@
    <include schemaLocation="sca-implementation-bpel-1.1-cd03.xsd"/>
    <include schemaLocation="sca-implementation-spring-1.1-csd01.xsd"/>
 
+   <!--
    <include schemaLocation="sca-binding-ws-1.1-cd04-rev2.xsd"/>
+   -->
    <include schemaLocation="sca-binding-ws-callback-1.1-cd04-rev1.xsd"/>
    <include schemaLocation="sca-binding-jms-1.1-csd05.xsd"/>
    <include schemaLocation="sca-binding-jca-1.1-cd04-rev2.xsd"/>   


### PR DESCRIPTION
This is a temporary fix only.  I have removed the include for sca-binding-ws-1.1-cd04-rev2.xsd, which imports wsdl20-instance.xsd for the wsdlLocation attribute.  I'm not sure why this schema fails to resolve while all the other schema work fine.  This needs to be investigated and fixed, at which point this workaround can be removed.
