### PR TITLE
Work for SWITCHYARD-217

### DIFF
--- a/deploy/jboss-as6/deployer/src/main/resources/META-INF/services/org.apache.camel.spi.PackageScanClassResolver
+++ b/deploy/jboss-as6/deployer/src/main/resources/META-INF/services/org.apache.camel.spi.PackageScanClassResolver
@@ -1,0 +1,1 @@
+org.apachextras.camel.jboss.JBossPackageScanClassResolver


### PR DESCRIPTION
Adding a ServerLoader to the camel component which enable a Camel
PackageScanClassResolver to be configured. We are specifying a
PackageScanClassResolver from the Camel Extra project which will be
picked up by the SwitchYard Camel if it is deployed in jboss-as6.
Note that camel-jboss6-<version>.jar must be inte jboss-as6 servers
classpath.
