### PR TITLE
SWITCHYARD-233 Add Java DSL support for Camel component

### DIFF
--- a/config/src/main/java/org/switchyard/config/model/composite/JavaComponentReferenceInterfaceModel.java
+++ b/config/src/main/java/org/switchyard/config/model/composite/JavaComponentReferenceInterfaceModel.java
@@ -1,0 +1,36 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+
+package org.switchyard.config.model.composite;
+
+import org.switchyard.config.model.composite.ComponentReferenceInterfaceModel;
+
+/**
+ * A "java" ComponentReferenceInterfaceModel.
+ *
+ * @author David Ward &lt;<a href="mailto:dward@jboss.org">dward@jboss.org</a>&gt; (C) 2011 Red Hat Inc.
+ */
+public interface JavaComponentReferenceInterfaceModel extends ComponentReferenceInterfaceModel {
+
+    /**
+     * The "java" implementation type.
+     */
+    public static final String JAVA = "java";
+
+}

--- a/config/src/main/java/org/switchyard/config/model/composite/JavaComponentServiceInterfaceModel.java
+++ b/config/src/main/java/org/switchyard/config/model/composite/JavaComponentServiceInterfaceModel.java
@@ -1,0 +1,36 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+
+package org.switchyard.config.model.composite;
+
+import org.switchyard.config.model.composite.ComponentServiceInterfaceModel;
+
+/**
+ * A "java" ComponentServiceInterfaceModel.
+ *
+ * @author David Ward &lt;<a href="mailto:dward@jboss.org">dward@jboss.org</a>&gt; (C) 2011 Red Hat Inc.
+ */
+public interface JavaComponentServiceInterfaceModel extends ComponentServiceInterfaceModel {
+
+    /**
+     * The "java" implementation type.
+     */
+    public static final String JAVA = "java";
+
+}

--- a/config/src/main/java/org/switchyard/config/model/composite/v1/V1JavaComponentReferenceInterfaceModel.java
+++ b/config/src/main/java/org/switchyard/config/model/composite/v1/V1JavaComponentReferenceInterfaceModel.java
@@ -1,0 +1,50 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+
+package org.switchyard.config.model.composite.v1;
+
+import org.switchyard.config.Configuration;
+import org.switchyard.config.model.Descriptor;
+import org.switchyard.config.model.composite.JavaComponentReferenceInterfaceModel;
+
+/**
+ * A "java" implementation of the ComponentReferenceInterfaceModel.
+ *
+ * @author David Ward &lt;<a href="mailto:dward@jboss.org">dward@jboss.org</a>&gt; (C) 2011 Red Hat Inc.
+ */
+public class V1JavaComponentReferenceInterfaceModel extends V1ComponentReferenceInterfaceModel implements JavaComponentReferenceInterfaceModel {
+
+    /**
+     * Default constructor for application use.
+     */
+    public V1JavaComponentReferenceInterfaceModel() {
+        super(JAVA);
+    }
+
+    /**
+     * Constructor for Marshaller use (ie: V1BeanMarshaller).
+     *
+     * @param config the Configuration
+     * @param desc the Descriptor
+     */
+    public V1JavaComponentReferenceInterfaceModel(Configuration config, Descriptor desc) {
+        super(config, desc);
+    }
+
+}

--- a/config/src/main/java/org/switchyard/config/model/composite/v1/V1JavaComponentServiceInterfaceModel.java
+++ b/config/src/main/java/org/switchyard/config/model/composite/v1/V1JavaComponentServiceInterfaceModel.java
@@ -1,0 +1,50 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+
+package org.switchyard.config.model.composite.v1;
+
+import org.switchyard.config.Configuration;
+import org.switchyard.config.model.Descriptor;
+import org.switchyard.config.model.composite.JavaComponentServiceInterfaceModel;
+
+/**
+ * A "java" implementation of the ComponentServiceInterfaceModel.
+ *
+ * @author David Ward &lt;<a href="mailto:dward@jboss.org">dward@jboss.org</a>&gt; (C) 2011 Red Hat Inc.
+ */
+public class V1JavaComponentServiceInterfaceModel extends V1ComponentServiceInterfaceModel implements JavaComponentServiceInterfaceModel {
+
+    /**
+     * Default constructor for application use.
+     */
+    public V1JavaComponentServiceInterfaceModel() {
+        super(JAVA);
+    }
+
+    /**
+     * Constructor for Marshaller use (ie: V1BeanMarshaller).
+     *
+     * @param config the Configuration
+     * @param desc the Descriptor
+     */
+    public V1JavaComponentServiceInterfaceModel(Configuration config, Descriptor desc) {
+        super(config, desc);
+    }
+
+}


### PR DESCRIPTION
Moved interface.java configuration support to core config since it is not specific to bean component.

https://issues.jboss.org/browse/SWITCHYARD-233

This will require a deploy to the maven repository as the change impacts the components repository.
