### PR TITLE
SWITCHYARD-237 Create a Transformer for Camel

### DIFF
--- a/deploy/jboss-as7/build/src/main/resources/modules/switchyard/transform/module.xml
+++ b/deploy/jboss-as7/build/src/main/resources/modules/switchyard/transform/module.xml
@@ -35,5 +35,12 @@
         <module name="org.switchyard.common"/>
         <module name="org.switchyard.config"/>
         <module name="org.milyn"/>
+        <module name="org.switchyard.component.camel" optional="true">
+            <imports>
+                <include-set>
+                    <path name="META-INF/switchyard"/>
+                </include-set>
+            </imports>
+        </module>
     </dependencies>
 </module>


### PR DESCRIPTION
The work on core involved adding the camel component as an optional
dependency module for the transfom module. This is done so that the
transform subsystem can "see" the META-INF/switchyard/transforms.xml
inte camel component. This file lists the transformer types which are
available in Camel as TypeConverters.
