### PR TITLE
SWITCHYARD-274

### DIFF
--- a/build/pom.xml
+++ b/build/pom.xml
@@ -59,6 +59,10 @@
       </license>
    </licenses>
 
+  <scm>
+    <url>http://github.com/switchyard/core</url>
+  </scm>
+
 
     <distributionManagement>
         <repository>


### PR DESCRIPTION
Adding missing SCM url, needed to pass staging repository verification.
