### PR TITLE
SWITCHYARD-341: Deployment.loadServiceInterface throws uninformative NPE 

### DIFF
--- a/deploy/base/src/main/java/org/switchyard/deploy/internal/Deployment.java
+++ b/deploy/base/src/main/java/org/switchyard/deploy/internal/Deployment.java
@@ -262,8 +262,14 @@ public class Deployment extends AbstractDeployment {
         
         if (intfModel != null) {
             if (isJavaInterface(intfModel.getType())) {
-                serviceInterface = JavaService.fromClass(
-                        loadClass(intfModel.getInterface()));
+                String interfaceClass = intfModel.getInterface();
+                Class<?> serviceInterfaceType = loadClass(interfaceClass);
+
+                if (serviceInterfaceType == null) {
+                    throw new SwitchYardException("Failed to load Service interface class '" + interfaceClass + "'.");
+                }
+
+                serviceInterface = JavaService.fromClass(serviceInterfaceType);
             } else if (intfModel.getType().equals(WSDL_INTERFACE)) {
                 try {
                     serviceInterface = WSDLService.fromWSDL(intfModel.getInterface());

--- a/deploy/base/src/test/java/org/switchyard/deploy/internal/DeploymentTest.java
+++ b/deploy/base/src/test/java/org/switchyard/deploy/internal/DeploymentTest.java
@@ -143,4 +143,19 @@ public class DeploymentTest {
         
         Assert.assertNotNull("Missing activator did not trigger SwitchYardException!", exception);
     }
+
+    @Test
+    public void testUnknownInterfaceClassName() throws Exception {
+        InputStream swConfigStream = Classes.getResourceAsStream("/switchyard-config-unknown-interface.xml", getClass());
+        Deployment deployment = new Deployment(swConfigStream);
+        swConfigStream.close();
+
+        deployment.init(ServiceDomainManager.createDomain());
+        try {
+            deployment.start();
+            Assert.fail("Expected SwitchYardException");
+        } catch (SwitchYardException e) {
+            Assert.assertEquals("Failed to load Service interface class 'org.acme.Blah'.", e.getMessage());
+        }
+    }
 }

--- a/deploy/base/src/test/resources/switchyard-config-handler-01.xml
+++ b/deploy/base/src/test/resources/switchyard-config-handler-01.xml
@@ -1,22 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-JBoss, Home of Professional Open Source
-Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
-as indicated by the @authors tag. All rights reserved.
-See the copyright.txt in the distribution for a
-full listing of individual contributors.
-
-This copyrighted material is made available to anyone wishing to use,
-modify, copy, or redistribute it subject to the terms and conditions
-of the GNU Lesser General Public License, v. 2.1.
-This program is distributed in the hope that it will be useful, but WITHOUT A
-WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
-PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
-You should have received a copy of the GNU Lesser General Public License,
-v.2.1 along with this distribution; if not, write to the Free Software
-Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
-MA  02110-1301, USA.
--->
+  ~ JBoss, Home of Professional Open Source
+  ~ Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+  ~ as indicated by the @authors tag. All rights reserved.
+  ~ See the copyright.txt in the distribution for a
+  ~ full listing of individual contributors.
+  ~ *
+  ~ This copyrighted material is made available to anyone wishing to use,
+  ~ modify, copy, or redistribute it subject to the terms and conditions
+  ~ of the GNU Lesser General Public License, v. 2.1.
+  ~ This program is distributed in the hope that it will be useful, but WITHOUT A
+  ~ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+  ~ PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+  ~ You should have received a copy of the GNU Lesser General Public License,
+  ~ v.2.1 along with this distribution; if not, write to the Free Software
+  ~ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+  ~ MA  02110-1301, USA.
+  -->
 <switchyard xmlns="urn:switchyard-config:switchyard:1.0">
     <domain>
         <handlers>

--- a/deploy/base/src/test/resources/switchyard-config-unknown-interface.xml
+++ b/deploy/base/src/test/resources/switchyard-config-unknown-interface.xml
@@ -1,0 +1,10 @@
+<switchyard xmlns="urn:switchyard-config:switchyard:1.0" xmlns:mock="urn:switchyard-component-mock:config:1.0">
+    <composite xmlns="http://docs.oasis-open.org/ns/opencsa/sca/200912" name="orders">
+        <component name="OrderService">
+            <service name="OrderService">
+                <interface.java interface="org.acme.Blah"/>
+            </service>
+            <mock:implementation.mock/>
+        </component>
+    </composite>
+</switchyard>


### PR DESCRIPTION
SWITCHYARD-341: Deployment.loadServiceInterface throws uninformative NPE if Service interface class not found

https://issues.jboss.org/browse/SWITCHYARD-341
