### PR TITLE
SWITCHYARD-351: targetNamespace being lost by switchyard plugin (ConfigMo

### DIFF
--- a/common/src/main/java/org/switchyard/common/io/pull/Puller.java
+++ b/common/src/main/java/org/switchyard/common/io/pull/Puller.java
@@ -16,7 +16,6 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, 
  * MA  02110-1301, USA.
  */
-
 package org.switchyard.common.io.pull;
 
 import java.io.File;

--- a/config/src/main/java/org/switchyard/config/BaseConfiguration.java
+++ b/config/src/main/java/org/switchyard/config/BaseConfiguration.java
@@ -43,6 +43,7 @@ public abstract class BaseConfiguration implements Configuration {
 
     protected static final String DEFAULT_XMLNS_URI = XMLConstants.XMLNS_ATTRIBUTE_NS_URI;
     protected static final String DEFAULT_XMLNS_PFX = "ns0";
+    protected static final String NULL_NS_URI = XMLConstants.NULL_NS_URI;
 
     private String[] _childrenOrder = new String[0];
 

--- a/config/src/main/java/org/switchyard/config/DOMConfiguration.java
+++ b/config/src/main/java/org/switchyard/config/DOMConfiguration.java
@@ -208,7 +208,13 @@ public class DOMConfiguration extends BaseConfiguration {
     @Override
     public boolean hasAttribute(QName qname) {
         if (qname != null) {
-            return _element.hasAttributeNS(qname.getNamespaceURI(), qname.getLocalPart());
+            String namespaceURI = qname.getNamespaceURI();
+            String localPart = qname.getLocalPart();
+            if (namespaceURI != null && !namespaceURI.equals(NULL_NS_URI)) {
+                return _element.hasAttributeNS(namespaceURI, localPart);
+            } else {
+                return hasAttribute(localPart);
+            }
         }
         return false;
     }
@@ -231,10 +237,16 @@ public class DOMConfiguration extends BaseConfiguration {
     @Override
     public String getAttribute(QName qname) {
         if (qname != null) {
-            Attr attr = _element.getAttributeNodeNS(qname.getNamespaceURI(), qname.getLocalPart());
-            if (attr != null) {
-                String value = attr.getValue();
-                return "".equals(value) ? null : value;
+            String namespaceURI = qname.getNamespaceURI();
+            String localPart = qname.getLocalPart();
+            if (namespaceURI != null && !namespaceURI.equals(NULL_NS_URI)) {
+                Attr attr = _element.getAttributeNodeNS(namespaceURI, localPart);
+                if (attr != null) {
+                    String value = attr.getValue();
+                    return "".equals(value) ? null : value;
+                }
+            } else {
+                return getAttribute(localPart);
             }
         }
         return null;
@@ -245,6 +257,9 @@ public class DOMConfiguration extends BaseConfiguration {
      */
     @Override
     public Configuration setAttribute(String name, String value) {
+        if (name == null) {
+            throw new IllegalArgumentException("name == null");
+        }
         if (value == null) {
             _element.removeAttribute(name);
         } else {
@@ -258,15 +273,20 @@ public class DOMConfiguration extends BaseConfiguration {
      */
     @Override
     public Configuration setAttribute(QName qname, String value) {
-        Attr attr = _element.getAttributeNodeNS(qname.getNamespaceURI(), qname.getLocalPart());
+        if (qname == null) {
+            throw new IllegalArgumentException("qname == null");
+        }
+        String namespaceURI = qname.getNamespaceURI();
+        String localPart = qname.getLocalPart();
+        Attr attr = _element.getAttributeNodeNS(namespaceURI, localPart);
         if (attr != null) {
             if (value == null) {
                 _element.removeAttributeNode(attr);
             } else {
                 attr.setValue(value);
             }
-        } else if (value != null && !DEFAULT_XMLNS_URI.equals(qname.getNamespaceURI())) {
-            attr = _element.getOwnerDocument().createAttributeNS(qname.getNamespaceURI(), qname.getLocalPart());
+        } else if (value != null && !DEFAULT_XMLNS_URI.equals(namespaceURI)) {
+            attr = _element.getOwnerDocument().createAttributeNS(namespaceURI, localPart);
             String prefix = qname.getPrefix();
             if (prefix != null  && prefix.length() > 0) {
                 attr.setPrefix(prefix);

--- a/config/src/main/java/org/switchyard/config/model/BaseModel.java
+++ b/config/src/main/java/org/switchyard/config/model/BaseModel.java
@@ -41,9 +41,9 @@ import org.switchyard.config.OutputKey;
  */
 public abstract class BaseModel implements Model {
 
-    private Configuration _config;
-    private Descriptor _desc;
-    private Map<Configuration,Model> _config_model_map;
+    private final Configuration _config;
+    private final Descriptor _desc;
+    private final Map<Configuration,Model> _config_model_map;
     private Model _parent;
 
     protected BaseModel(QName qname) {

--- a/config/src/main/java/org/switchyard/config/model/MergeScanner.java
+++ b/config/src/main/java/org/switchyard/config/model/MergeScanner.java
@@ -31,9 +31,9 @@ import java.util.List;
  */
 public class MergeScanner<M extends Model> implements Scanner<M> {
 
-    private Class<M> _clazz;
-    private boolean _fromOverridesTo;
-    private List<Scanner<M>> _scanners;
+    private final Class<M> _clazz;
+    private final boolean _fromOverridesTo;
+    private final List<Scanner<M>> _scanners;
 
     /**
      * Constructs a new MergeScanner using the specified parameters.
@@ -87,7 +87,6 @@ public class MergeScanner<M extends Model> implements Scanner<M> {
         }
         for (Scanner<M> scanner : _scanners) {
             ScannerOutput<M> scannerOutput = scanner.scan(input);
-
             if (scannerOutput != null) {
                 List<M> scanned_list = scannerOutput.getModels();
                 if (scanned_list != null) {

--- a/config/src/main/java/org/switchyard/config/model/ModelPullerScanner.java
+++ b/config/src/main/java/org/switchyard/config/model/ModelPullerScanner.java
@@ -27,6 +27,7 @@ import java.net.URL;
 
 import javax.xml.namespace.QName;
 
+import org.switchyard.common.io.resource.Resource;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.xml.sax.InputSource;
@@ -41,9 +42,10 @@ import org.xml.sax.InputSource;
 public class ModelPullerScanner<M extends Model> implements Scanner<M> {
 
     private Type _type;
-    private String _resource;
+    private String _classpath;
     private URI _uri;
     private URL _url;
+    private Resource _resource;
     private File _file;
     private InputStream _inputStream;
     private Reader _reader;
@@ -53,23 +55,23 @@ public class ModelPullerScanner<M extends Model> implements Scanner<M> {
     private QName _qname;
 
     /**
-     * Constructs a default ModelResourceScanner that scans for "/META-INF/switchyard.xml" resource(s).
+     * Constructs a default ModelPullerScanner that scans for "/META-INF/switchyard.xml" resource(s).
      */
     public ModelPullerScanner() {
         this("/META-INF/switchyard.xml");
     }
 
     /**
-     * Constructs a ModelResourceScanner that scans for the specified resource.
-     * @param resource the resource
+     * Constructs a ModelPullerScanner that scans for the specified classpath resource.
+     * @param classpath the classpath resource
      */
-    public ModelPullerScanner(String resource) {
-        _type = Type.RESOURCE;
-        _resource = resource;
+    public ModelPullerScanner(String classpath) {
+        _type = Type.CLASSPATH;
+        _classpath = classpath;
     }
 
     /**
-     * Constructs a ModelResourceScanner that scans for the specified URI.
+     * Constructs a ModelPullerScanner that scans for the specified URI.
      * @param uri the URI
      */
     public ModelPullerScanner(URI uri) {
@@ -78,7 +80,7 @@ public class ModelPullerScanner<M extends Model> implements Scanner<M> {
     }
 
     /**
-     * Constructs a ModelResourceScanner that scans for the specified URL.
+     * Constructs a ModelPullerScanner that scans for the specified URL.
      * @param url the URL
      */
     public ModelPullerScanner(URL url) {
@@ -87,7 +89,16 @@ public class ModelPullerScanner<M extends Model> implements Scanner<M> {
     }
 
     /**
-     * Constructs a ModelResourceScanner that scans for the specified File.
+     * Constructs a ModelPullerScanner that scans for the specified Resource.
+     * @param resource the Resource
+     */
+    public ModelPullerScanner(Resource resource) {
+        _type = Type.RESOURCE;
+        _resource = resource;
+    }
+
+    /**
+     * Constructs a ModelPullerScanner that scans for the specified File.
      * @param file the File
      */
     public ModelPullerScanner(File file) {
@@ -96,7 +107,7 @@ public class ModelPullerScanner<M extends Model> implements Scanner<M> {
     }
 
     /**
-     * Constructs a ModelResourceScanner that scans for the specified InputStream.
+     * Constructs a ModelPullerScanner that scans for the specified InputStream.
      * @param inputStream the InputStream
      */
     public ModelPullerScanner(InputStream inputStream) {
@@ -105,7 +116,7 @@ public class ModelPullerScanner<M extends Model> implements Scanner<M> {
     }
 
     /**
-     * Constructs a ModelResourceScanner that scans for the specified Reader.
+     * Constructs a ModelPullerScanner that scans for the specified Reader.
      * @param reader the Reader
      */
     public ModelPullerScanner(Reader reader) {
@@ -114,7 +125,7 @@ public class ModelPullerScanner<M extends Model> implements Scanner<M> {
     }
 
     /**
-     * Constructs a ModelResourceScanner that scans for the specified InputSource.
+     * Constructs a ModelPullerScanner that scans for the specified InputSource.
      * @param inputSource the InputSource
      */
     public ModelPullerScanner(InputSource inputSource) {
@@ -123,7 +134,7 @@ public class ModelPullerScanner<M extends Model> implements Scanner<M> {
     }
 
     /**
-     * Constructs a ModelResourceScanner that scans for the specified Document.
+     * Constructs a ModelPullerScanner that scans for the specified Document.
      * @param document the Document
      */
     public ModelPullerScanner(Document document) {
@@ -132,7 +143,7 @@ public class ModelPullerScanner<M extends Model> implements Scanner<M> {
     }
 
     /**
-     * Constructs a ModelResourceScanner that scans for the specified Element.
+     * Constructs a ModelPullerScanner that scans for the specified Element.
      * @param element the Element
      */
     public ModelPullerScanner(Element element) {
@@ -141,7 +152,7 @@ public class ModelPullerScanner<M extends Model> implements Scanner<M> {
     }
 
     /**
-     * Constructs a ModelResourceScanner that scans for the specified QName.
+     * Constructs a ModelPullerScanner that scans for the specified QName.
      * @param qname the QName
      */
     public ModelPullerScanner(QName qname) {
@@ -156,14 +167,17 @@ public class ModelPullerScanner<M extends Model> implements Scanner<M> {
     public ScannerOutput<M> scan(ScannerInput<M> input) throws IOException {
         M model;
         switch (_type) {
-            case RESOURCE:
-                model = new ModelPuller<M>().pull(_resource, getClass());
+            case CLASSPATH:
+                model = new ModelPuller<M>().pull(_classpath, getClass());
                 break;
             case URI:
                 model = new ModelPuller<M>().pull(_uri);
                 break;
             case URL:
                 model = new ModelPuller<M>().pull(_url);
+                break;
+            case RESOURCE:
+                model = new ModelPuller<M>().pull(_resource);
                 break;
             case FILE:
                 model = new ModelPuller<M>().pull(_file);
@@ -193,7 +207,7 @@ public class ModelPullerScanner<M extends Model> implements Scanner<M> {
     }
 
     private static enum Type {
-        RESOURCE, URI, URL, FILE, INPUT_STREAM, READER, INPUT_SOURCE, DOCUMENT, ELEMENT, QNAME;
+        CLASSPATH, URI, URL, RESOURCE, FILE, INPUT_STREAM, READER, INPUT_SOURCE, DOCUMENT, ELEMENT, QNAME;
     }
 
 }

--- a/tools/maven/plugins/switchyard/src/main/java/org/switchyard/tools/maven/plugins/switchyard/ConfigureMojo.java
+++ b/tools/maven/plugins/switchyard/src/main/java/org/switchyard/tools/maven/plugins/switchyard/ConfigureMojo.java
@@ -16,7 +16,6 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, 
  * MA  02110-1301, USA.
  */
-
 package org.switchyard.tools.maven.plugins.switchyard;
 
 import java.io.BufferedWriter;


### PR DESCRIPTION
SWITCHYARD-351: targetNamespace being lost by switchyard plugin (ConfigMojo) during final switchyard.xml generation
https://issues.jboss.org/browse/SWITCHYARD-351
