### PR TITLE
SWITCHYARD-365: targetNamespace is being ignored by NamedModel.getQName()

### DIFF
--- a/config/src/main/java/org/switchyard/config/model/BaseNamedModel.java
+++ b/config/src/main/java/org/switchyard/config/model/BaseNamedModel.java
@@ -18,8 +18,11 @@
  */
 package org.switchyard.config.model;
 
+import java.net.URI;
+
 import javax.xml.namespace.QName;
 
+import org.switchyard.common.lang.Strings;
 import org.switchyard.common.xml.XMLHelper;
 import org.switchyard.config.Configuration;
 
@@ -63,17 +66,34 @@ public abstract class BaseNamedModel extends BaseModel implements NamedModel {
      * {@inheritDoc}
      */
     @Override
-    public QName getQName() {
-        return XMLHelper.createQName(getName());
+    public String getTargetNamespace() {
+        String tns = null;
+        Model model = this;
+        while (model instanceof BaseModel) {
+            tns = Strings.trimToNull(((BaseModel)model).getModelAttribute("targetNamespace"));
+            if (tns != null) {
+                break;
+            }
+            model = model.getModelParent();
+        }
+        return tns;
     }
 
     /**
      * {@inheritDoc}
      */
     @Override
-    public NamedModel setQName(QName qname) {
-        setName(qname != null ? qname.toString() : null);
-        return this;
+    public URI getTargetNamespaceURI() {
+        String tns = getTargetNamespace();
+        return tns != null ? URI.create(tns) : null;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public QName getQName() {
+        return XMLHelper.createQName(getTargetNamespace(), getName());
     }
 
 }

--- a/config/src/main/java/org/switchyard/config/model/NamedModel.java
+++ b/config/src/main/java/org/switchyard/config/model/NamedModel.java
@@ -18,6 +18,8 @@
  */
 package org.switchyard.config.model;
 
+import java.net.URI;
+
 import javax.xml.namespace.QName;
 
 /**
@@ -41,16 +43,21 @@ public interface NamedModel extends Model {
     public NamedModel setName(String name);
 
     /**
+     * Gets the targetNamespace of this Model from the wrapped Configuration.
+     * @return the targetNamespace
+     */
+    public String getTargetNamespace();
+
+    /**
+     * Gets the targetNamespace URI of this Model from the wrapped Configuration.
+     * @return the targetNamespace URI
+     */
+    public URI getTargetNamespaceURI();
+
+    /**
      * Gets the qualified name <b>attribute</b> of this Model (<i>not</i> the qualified name of the wrapped Configuration).
      * @return the qualified name
      */
     public QName getQName();
-
-    /**
-     * Sets the qualified name <b>attribute</b> of this Model (<i>not</i> the qualified name of the wrapped Configuration).
-     * @param qname the qualified name
-     * @return this NamedModel (useful for chaining)
-     */
-    public NamedModel setQName(QName qname);
 
 }

--- a/config/src/main/resources/org/oasis-open/docs/ns/opencsa/sca/200912/sca-core-1.1-cd06.xsd
+++ b/config/src/main/resources/org/oasis-open/docs/ns/opencsa/sca/200912/sca-core-1.1-cd06.xsd
@@ -68,7 +68,12 @@
                     maxOccurs="unbounded"/>
             </sequence>
             <attribute name="name" type="NCName" use="required"/>
+            <!--
+            Original (use="required"):
             <attribute name="targetNamespace" type="anyURI" use="required"/>
+            SwitchYard (use="optional"):
+            -->
+            <attribute name="targetNamespace" type="anyURI" use="optional"/>
             <attribute name="local" type="boolean" use="optional" 
                        default="false"/>
             <attribute name="autowire" type="boolean" use="optional" 

--- a/config/src/main/resources/org/oasis-open/docs/ns/opencsa/sca/200912/sca-definitions-1.1-cd06.xsd
+++ b/config/src/main/resources/org/oasis-open/docs/ns/opencsa/sca/200912/sca-definitions-1.1-cd06.xsd
@@ -23,7 +23,12 @@
                <any namespace="##other" processContents="lax" 
                   minOccurs="0" maxOccurs="unbounded"/>
             </choice>
+            <!--
+            Original (use="required"):
             <attribute name="targetNamespace" type="anyURI" use="required"/>
+            SwitchYard (use="optional"):
+            -->
+            <attribute name="targetNamespace" type="anyURI" use="optional"/>
          </extension>
       </complexContent>
    </complexType>

--- a/config/src/test/java/org/switchyard/config/ConfigurationTests.java
+++ b/config/src/test/java/org/switchyard/config/ConfigurationTests.java
@@ -123,6 +123,7 @@ public class ConfigurationTests {
     @Test
     public void testNamespacesValues() throws Exception {
         Configuration config = _cfg_puller.pull(NAMESPACES_XML, getClass());
+        Assert.assertEquals("urn:test", config.getAttribute("targetNamespace"));
         Assert.assertEquals("http://a.org/a.xsd", config.getQName().getNamespaceURI());
         Assert.assertEquals("bar", config.getAttribute("foo"));
         Assert.assertEquals("stuff", config.getFirstChild("two").getValue());

--- a/config/src/test/java/org/switchyard/config/model/switchyard/SwitchYardModelTests.java
+++ b/config/src/test/java/org/switchyard/config/model/switchyard/SwitchYardModelTests.java
@@ -33,6 +33,9 @@ import org.switchyard.common.xml.XMLHelper;
 import org.switchyard.config.model.Model;
 import org.switchyard.config.model.ModelPuller;
 import org.switchyard.config.model.Models;
+import org.switchyard.config.model.composite.ComponentModel;
+import org.switchyard.config.model.composite.ComponentReferenceModel;
+import org.switchyard.config.model.composite.ComponentServiceModel;
 import org.switchyard.config.model.composite.CompositeModel;
 import org.switchyard.config.model.composite.CompositeServiceModel;
 import org.switchyard.config.model.composite.test.soap.PortModel;
@@ -134,6 +137,29 @@ public class SwitchYardModelTests {
     public void testValidation() throws Exception {
         SwitchYardModel switchyard = _puller.pull(COMPLETE_XML, getClass());
         Assert.assertTrue(switchyard.isModelValid());
+    }
+
+    @Test
+    public void testTargetNamespace() throws Exception {
+        SwitchYardModel switchyard = _puller.pull(COMPLETE_XML, getClass());
+        final String tns = "urn:m1app:example:1.0";
+        Assert.assertEquals("m1app", switchyard.getName());
+        Assert.assertEquals(new QName(tns, "m1app"), switchyard.getQName());
+        CompositeModel composite = switchyard.getComposite();
+        Assert.assertEquals("m1app", composite.getName());
+        Assert.assertEquals(new QName(tns, "m1app"), composite.getQName());
+        CompositeServiceModel compositeService = composite.getServices().iterator().next();
+        Assert.assertEquals("M1AppService", compositeService.getName());
+        Assert.assertEquals(new QName(tns, "M1AppService"), compositeService.getQName());
+        ComponentModel component = composite.getComponents().iterator().next();
+        Assert.assertEquals("SimpleService", component.getName());
+        Assert.assertEquals(new QName(tns, "SimpleService"), component.getQName());
+        ComponentServiceModel componentService = component.getServices().iterator().next();
+        Assert.assertEquals("SimpleService", componentService.getName());
+        Assert.assertEquals(new QName(tns, "SimpleService"), componentService.getQName());
+        ComponentReferenceModel componentReference = component.getReferences().iterator().next();
+        Assert.assertEquals("anotherService", componentReference.getName());
+        Assert.assertEquals(new QName(tns, "anotherService"), componentReference.getQName());
     }
 
 }

--- a/config/src/test/resources/org/switchyard/config/ConfigurationTests-Namespaces.xml
+++ b/config/src/test/resources/org/switchyard/config/ConfigurationTests-Namespaces.xml
@@ -17,7 +17,7 @@ v.2.1 along with this distribution; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
 MA  02110-1301, USA.
 -->
-<one xmlns='http://a.org/a.xsd' xmlns:b='http://b.org/b.xsd' xmlns:c='http://c.org/c.xsd' foo='bar'>
+<one xmlns='http://a.org/a.xsd' xmlns:b='http://b.org/b.xsd' xmlns:c='http://c.org/c.xsd' foo='bar' targetNamespace='urn:test'>
     <b:two baz='whiz' c:boy='girl'>stuff</b:two>
     <three toy='robot' b:man='woman'>junk</three>
 </one>

--- a/config/src/test/resources/org/switchyard/config/model/switchyard/SwitchYardModelTests-Complete.xml
+++ b/config/src/test/resources/org/switchyard/config/model/switchyard/SwitchYardModelTests-Complete.xml
@@ -22,8 +22,10 @@ MA  02110-1301, USA.
             xmlns:soap="urn:switchyard-config:test-soap:1.0"
             xmlns:bean="urn:switchyard-config:test-bean:1.0"
             xmlns:java="urn:switchyard-config:test-java:1.0"
-            xmlns:smooks="urn:switchyard-config:test-smooks:1.0">
-    <sca:composite name="m1app" targetNamespace="urn:m1app:example:1.0">
+            xmlns:smooks="urn:switchyard-config:test-smooks:1.0"
+            targetNamespace="urn:m1app:example:1.0"
+            name="m1app">
+    <sca:composite name="m1app">
         <sca:service name="M1AppService" promote="SimpleService">
             <soap:binding.soap>
                 <soap:port secure="true">MyWebService/SOAPPort</soap:port>

--- a/config/src/test/resources/org/switchyard/config/model/switchyard/SwitchYardModelTests-Fragment.xml
+++ b/config/src/test/resources/org/switchyard/config/model/switchyard/SwitchYardModelTests-Fragment.xml
@@ -19,8 +19,10 @@ MA  02110-1301, USA.
 -->
 <switchyard xmlns="urn:switchyard-config:switchyard:1.0"
             xmlns:sca="http://docs.oasis-open.org/ns/opencsa/sca/200912"
-            xmlns:soap="urn:switchyard-config:test-soap:1.0">
-    <sca:composite name="m1app" targetNamespace="urn:m1app:example:1.0">
+            xmlns:soap="urn:switchyard-config:test-soap:1.0"
+            targetNamespace="urn:m1app:example:1.0"
+            name="m1app">
+    <sca:composite name="m1app">
         <sca:service name="M1AppService" promote="SimpleService">
             <soap:binding.soap>
                 <soap:port secure="true">MyWebService/SOAPPort</soap:port>

--- a/config/src/test/resources/org/switchyard/config/model/switchyard/SwitchYardModelTests-Incomplete.xml
+++ b/config/src/test/resources/org/switchyard/config/model/switchyard/SwitchYardModelTests-Incomplete.xml
@@ -22,7 +22,7 @@ MA  02110-1301, USA.
             xmlns:bean="urn:switchyard-config:test-bean:1.0"
             xmlns:java="urn:switchyard-config:test-java:1.0"
             xmlns:smooks="urn:switchyard-config:test-smooks:1.0">
-    <sca:composite name="m1app" targetNamespace="urn:m1app:example:1.0">
+    <sca:composite name="m1app">
         <sca:component name="SimpleService">
             <bean:implementation.bean class="org.switchyard.example.m1app.SimpleBean"/>
             <sca:service name="SimpleService">

--- a/deploy/base/src/test/java/org/switchyard/deploy/internal/DeploymentTest.java
+++ b/deploy/base/src/test/java/org/switchyard/deploy/internal/DeploymentTest.java
@@ -107,8 +107,7 @@ public class DeploymentTest {
         deployment.init(ServiceDomainManager.createDomain());
         deployment.start();
 
-        // FIXME: new QName("urn:switchyard-interface-wsdl", "HelloService") does not work
-        ServiceReference service = deployment.getDomain().getService(new QName("HelloService"));
+        ServiceReference service = deployment.getDomain().getService(new QName("urn:switchyard-interface-wsdl", "HelloService"));
         Assert.assertNotNull(service);
         ServiceInterface iface = service.getInterface();
         Assert.assertEquals(WSDLService.TYPE, iface.getType());

--- a/test/src/main/java/org/switchyard/test/Invoker.java
+++ b/test/src/main/java/org/switchyard/test/Invoker.java
@@ -33,6 +33,7 @@ import org.switchyard.HandlerException;
 import org.switchyard.Message;
 import org.switchyard.ServiceDomain;
 import org.switchyard.ServiceReference;
+import org.switchyard.common.xml.XMLHelper;
 import org.switchyard.metadata.BaseExchangeContract;
 import org.switchyard.metadata.ExchangeContract;
 import org.switchyard.metadata.InOnlyOperation;
@@ -64,16 +65,7 @@ public class Invoker {
      * @param serviceName The Service name.
      */
     protected Invoker(ServiceDomain domain, String serviceName) {
-        _domain = domain;
-
-        String[] serviceNameTokens = serviceName.split("\\.");
-
-        if (serviceNameTokens.length == 1) {
-            _serviceName = QName.valueOf(serviceName);
-        } else if (serviceNameTokens.length == 2) {
-            _serviceName = QName.valueOf(serviceNameTokens[0]);
-            _operationName = serviceNameTokens[1];
-        }
+        this(domain, XMLHelper.createQName(domain.getName().getNamespaceURI(), serviceName));
     }
 
     /**
@@ -83,7 +75,15 @@ public class Invoker {
      */
     public Invoker(ServiceDomain domain, QName serviceName) {
         _domain = domain;
-        _serviceName = serviceName;
+
+        String[] serviceNameTokens = serviceName.getLocalPart().split("\\.");
+
+        if (serviceNameTokens.length == 1) {
+            _serviceName = serviceName;
+        } else if (serviceNameTokens.length == 2) {
+            _serviceName = XMLHelper.createQName(serviceName.getNamespaceURI(), serviceNameTokens[0]);
+            _operationName = serviceNameTokens[1];
+        }
     }
 
     /**

--- a/test/src/main/java/org/switchyard/test/SwitchYardTestKit.java
+++ b/test/src/main/java/org/switchyard/test/SwitchYardTestKit.java
@@ -16,8 +16,23 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
  * MA  02110-1301, USA.
  */
-
 package org.switchyard.test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UnsupportedEncodingException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import javax.xml.namespace.QName;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
 
 import org.apache.log4j.Logger;
 import org.custommonkey.xmlunit.XMLAssert;
@@ -27,6 +42,7 @@ import org.switchyard.ExchangeHandler;
 import org.switchyard.ServiceDomain;
 import org.switchyard.common.type.Classes;
 import org.switchyard.common.type.classpath.ClasspathScanner;
+import org.switchyard.common.xml.XMLHelper;
 import org.switchyard.config.model.MergeScanner;
 import org.switchyard.config.model.Model;
 import org.switchyard.config.model.ModelPuller;
@@ -50,21 +66,6 @@ import org.switchyard.transform.BaseTransformer;
 import org.switchyard.transform.Transformer;
 import org.switchyard.transform.TransformerUtil;
 import org.w3c.dom.Document;
-
-import javax.xml.namespace.QName;
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.UnsupportedEncodingException;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.net.URLClassLoader;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
 
 /**
  * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
@@ -231,6 +232,16 @@ public class SwitchYardTestKit {
     }
 
     /**
+     * Creates a QName given this test kit's config model's targetNamespace + the specified localPart.
+     * @param localPart the specified localPart
+     * @return the QName
+     */
+    public QName createQName(String localPart) {
+        String tns = _configModel != null ? _configModel.getTargetNamespace() : null;
+        return XMLHelper.createQName(tns, localPart);
+    }
+
+    /**
      * Register an IN_OUT Service.
      * <p/>
      * Registers a {@link MockHandler} as the service handler.
@@ -240,7 +251,7 @@ public class SwitchYardTestKit {
      */
     public MockHandler registerInOutService(String serviceName) {
         MockHandler handler = new MockHandler();
-        getServiceDomain().registerService(QName.valueOf(serviceName), handler, new InOutService());
+        getServiceDomain().registerService(createQName(serviceName), handler, new InOutService());
         return handler;
     }
 
@@ -251,7 +262,7 @@ public class SwitchYardTestKit {
      * @param serviceHandler The service handler.
      */
     public void registerInOutService(String serviceName, ExchangeHandler serviceHandler) {
-        getServiceDomain().registerService(QName.valueOf(serviceName), serviceHandler, new InOutService());
+        getServiceDomain().registerService(createQName(serviceName), serviceHandler, new InOutService());
     }
 
     /**
@@ -262,7 +273,7 @@ public class SwitchYardTestKit {
      * @param metadata Service interface.
      */
     public void registerInOutService(String serviceName, ExchangeHandler serviceHandler, ServiceInterface metadata) {
-        getServiceDomain().registerService(QName.valueOf(serviceName), serviceHandler, metadata);
+        getServiceDomain().registerService(createQName(serviceName), serviceHandler, metadata);
     }
 
     /**
@@ -275,7 +286,7 @@ public class SwitchYardTestKit {
      */
     public MockHandler registerInOnlyService(String serviceName) {
         MockHandler handler = new MockHandler();
-        getServiceDomain().registerService(QName.valueOf(serviceName), handler, new InOnlyService());
+        getServiceDomain().registerService(createQName(serviceName), handler, new InOnlyService());
         return handler;
     }
 
@@ -286,7 +297,7 @@ public class SwitchYardTestKit {
      * @param serviceHandler The service handler.
      */
     public void registerInOnlyService(String serviceName, ExchangeHandler serviceHandler) {
-        getServiceDomain().registerService(QName.valueOf(serviceName), serviceHandler, new InOnlyService());
+        getServiceDomain().registerService(createQName(serviceName), serviceHandler, new InOnlyService());
     }
 
     /**
@@ -313,7 +324,7 @@ public class SwitchYardTestKit {
      * @return The invoker instance.
      */
     public Invoker newInvoker(String serviceName) {
-        return new Invoker(getServiceDomain(), serviceName);
+        return newInvoker(createQName(serviceName));
     }
 
     /**


### PR DESCRIPTION
SWITCHYARD-365: targetNamespace is being ignored by NamedModel.getQName()
https://issues.jboss.org/browse/SWITCHYARD-365
