### PR TITLE
SWITCHYARD-390: Duplicate Transfomer 'org.switchyard.component.hornetq.tr

### DIFF
--- a/transform/src/main/java/org/switchyard/transform/TransformerRegistryLoader.java
+++ b/transform/src/main/java/org/switchyard/transform/TransformerRegistryLoader.java
@@ -134,7 +134,7 @@ public class TransformerRegistryLoader {
                     TransformsModel transformsModel = new ModelPuller<TransformsModel>().pull(configStream);
                     registerTransformers(transformsModel);
                 } catch (final DuplicateTransformerException e) {
-                    _log.warn(e.getMessage(), e);
+                    _log.debug(e.getMessage(), e);
                 } finally {
                     configStream.close();
                 }


### PR DESCRIPTION
SWITCHYARD-390: Duplicate Transfomer 'org.switchyard.component.hornetq.transformer.ByteArrayToStringTransformer' defined in main and test causes a stack trace in tests
https://issues.jboss.org/browse/SWITCHYARD-390
