### PR TITLE
SWITCHYARD-397: Issue with CDIMixIn when Camel and CDI tests exist in sam

### DIFF
--- a/test/src/main/java/org/switchyard/test/SwitchYardRunner.java
+++ b/test/src/main/java/org/switchyard/test/SwitchYardRunner.java
@@ -71,8 +71,14 @@ public class SwitchYardRunner extends BlockJUnit4ClassRunner {
 
     @Override
     public void run(RunNotifier notifier) {
-        notifier.addListener(new TestLifecycleListener());
-        super.run(notifier);
+        TestLifecycleListener listener = new TestLifecycleListener();
+
+        notifier.addListener(listener);
+        try {
+            super.run(notifier);
+        } finally {
+            notifier.removeListener(listener);
+        }
     }
 
     private class TestLifecycleListener extends RunListener {

--- a/test/src/main/java/org/switchyard/test/mixins/CDIMixIn.java
+++ b/test/src/main/java/org/switchyard/test/mixins/CDIMixIn.java
@@ -165,8 +165,13 @@ public class CDIMixIn extends AbstractTestMixIn {
     }
 
     @Override
-    public void uninitialize() {
-        _weld.shutdown();
+    public synchronized void uninitialize() {
+        if (_weld != null) {
+            _weld.shutdown();
+            _weld = null;
+        } else {
+            Thread.dumpStack();
+        }
     }
 
     private Object createBeanInstance(Bean<?> bean) {

--- a/test/src/test/java/org/switchyard/test/mixins/CDIMixInStopStartTest.java
+++ b/test/src/test/java/org/switchyard/test/mixins/CDIMixInStopStartTest.java
@@ -1,0 +1,39 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+
+package org.switchyard.test.mixins;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.switchyard.test.SwitchYardRunner;
+
+/**
+ * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
+ */
+@RunWith(SwitchYardRunner.class)
+public class CDIMixInStopStartTest {
+
+    @Test
+    public void test() {
+        CDIMixIn mixIn = new CDIMixIn();
+
+        mixIn.initialize();
+        mixIn.uninitialize();
+    }
+}


### PR DESCRIPTION
SWITCHYARD-397: Issue with CDIMixIn when Camel and CDI tests exist in same project

https://issues.jboss.org/browse/SWITCHYARD-397
