### PR TITLE
SWITCHYARD-409: Remove unused required JAXB attributes from transform sch

### DIFF
--- a/transform/src/main/resources/org/switchyard/transform/config/model/v1/transform-v1.xsd
+++ b/transform/src/main/resources/org/switchyard/transform/config/model/v1/transform-v1.xsd
@@ -160,24 +160,7 @@ MA  02110-1301, USA.
             </documentation>
         </annotation>
         <complexContent>
-            <extension base="swyd:TransformType">
-                <attribute name="type" type="trfm:javaTransformType" use="required">
-                    <annotation>
-                        <documentation xml:lang="en">
-                            Transform type.
-                        </documentation>
-                    </annotation>
-                </attribute>
-                <attribute name="contextPath" type="string" use="required">
-                    <annotation>
-                        <documentation xml:lang="en">
-                            List of java package names that contain schema
-                            derived class and/or java to schema (JAXB-annotated)
-                            mapped classes.
-                        </documentation>
-                    </annotation>
-                </attribute>
-            </extension>
+            <extension base="swyd:TransformType" />
         </complexContent>
     </complexType>
 


### PR DESCRIPTION
SWITCHYARD-409: Remove unused required JAXB attributes from transform schema

https://issues.jboss.org/browse/SWITCHYARD-409
