### PR TITLE
SWITCHYARD-423: merged config is not schema valid

### DIFF
--- a/admin/src/main/java/org/switchyard/admin/base/SwitchYardBuilder.java
+++ b/admin/src/main/java/org/switchyard/admin/base/SwitchYardBuilder.java
@@ -184,7 +184,7 @@ public class SwitchYardBuilder implements DeploymentListener {
             String bindingConfiguration = null;
             ByteArrayOutputStream baos = new ByteArrayOutputStream();
             try {
-                bindingModel.getModelConfiguration().write(baos, OutputKey.OMIT_XML_DECLARATION);
+                bindingModel.getModelConfiguration().write(baos, OutputKey.EXCLUDE_XML_DECLARATION);
                 bindingConfiguration = baos.toString();
             } catch (IOException e) {
                 // FIXME: do we need to log this?
@@ -277,7 +277,7 @@ public class SwitchYardBuilder implements DeploymentListener {
         String configuration = null;
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         try {
-            implementationModel.getModelConfiguration().write(baos, OutputKey.OMIT_XML_DECLARATION);
+            implementationModel.getModelConfiguration().write(baos, OutputKey.EXCLUDE_XML_DECLARATION);
             configuration = baos.toString();
         } catch (IOException e) {
             // FIXME: do we need to log this?

--- a/common/src/main/java/org/switchyard/common/io/pull/Puller.java
+++ b/common/src/main/java/org/switchyard/common/io/pull/Puller.java
@@ -69,7 +69,7 @@ public abstract class Puller<R> {
     /**
      * Safely pulls a resource from a path using {@link org.switchyard.common.type.Classes#getResourceAsStream(String, ClassLoader)}.
      * @param resource the path to the resource
-     * @param loader classloader we can also try to find the resource
+     * @param loader the classloader we can also try to find the resource
      * @return the resource, or null if not found
      * @throws IOException if a problem occurred
      */
@@ -119,7 +119,29 @@ public abstract class Puller<R> {
      * @throws IOException if a problem occurred
      */
     public R pull(Resource resource) throws IOException {
-        return pull(resource.getLocationURL());
+        return pull(resource, getClass());
+    }
+
+    /**
+     * Safely pulls a resource from a Resource, using the specified caller class.
+     * @param resource the Resource
+     * @param caller the class calling this method
+     * @return the resource, or null if not found
+     * @throws IOException if a problem occurred
+     */
+    public R pull(Resource resource, Class<?> caller) throws IOException {
+        return pull(resource.getLocationURL(caller));
+    }
+
+    /**
+     * Safely pulls a resource from a Resource, using the specified classloader.
+     * @param resource the Resource
+     * @param loader the classloader to check with
+     * @return the resource, or null if not found
+     * @throws IOException if a problem occurred
+     */
+    public R pull(Resource resource, ClassLoader loader) throws IOException {
+        return pull(resource.getLocationURL(loader));
     }
 
     /**

--- a/common/src/main/java/org/switchyard/common/io/resource/BaseResource.java
+++ b/common/src/main/java/org/switchyard/common/io/resource/BaseResource.java
@@ -48,12 +48,34 @@ public abstract class BaseResource implements Resource {
     }
 
     /**
+     * {@inheritDoc}
+     */
+    @Override
+    public URL getLocationURL(ClassLoader loader) {
+        return getURL(getLocation(), loader);
+    }
+
+    /**
      * Gets a URL with the specified location and calling class.
      * @param location the specified location
      * @param caller the calling class to use it's classloader
      * @return the URL
      */
-    public static URL getURL(String location, Class<?> caller) {
+    public static final URL getURL(String location, Class<?> caller) {
+        return getURL(location, caller, null);
+    }
+
+    /**
+     * Gets a URL with the specified location and calling class.
+     * @param location the specified location
+     * @param loader the classloader to check with
+     * @return the URL
+     */
+    public static final URL getURL(String location, ClassLoader loader) {
+        return getURL(location, null, loader);
+    }
+
+    private static final URL getURL(String location, Class<?> caller, ClassLoader loader) {
         if (location != null) {
             try {
                 if (location.startsWith("http:") || location.startsWith("https:")) {
@@ -62,11 +84,17 @@ public abstract class BaseResource implements Resource {
                 if (location.startsWith("file:")) {
                     return new File(location.substring(5)).toURI().toURL();
                 }
-                return Classes.getResource(location, caller);
+                if (caller != null) {
+                    return Classes.getResource(location, caller);
+                }
+                if (loader != null) {
+                    return Classes.getResource(location, loader);
+                }
             } catch (IOException ioe) {
                 return null;
             }
         }
         return null;
     }
+
 }

--- a/common/src/main/java/org/switchyard/common/io/resource/Resource.java
+++ b/common/src/main/java/org/switchyard/common/io/resource/Resource.java
@@ -47,6 +47,13 @@ public interface Resource {
     public URL getLocationURL(Class<?> caller);
 
     /**
+     * Gets the URL form of the resource's location.
+     * @param loader the classloader to check with
+     * @return the URL form of the resource's location
+     */
+    public URL getLocationURL(ClassLoader loader);
+
+    /**
      * Gets the type of the resource.
      * @return the type of the resource
      */

--- a/config/src/main/java/org/switchyard/config/Configurations.java
+++ b/config/src/main/java/org/switchyard/config/Configurations.java
@@ -73,6 +73,7 @@ public final class Configurations {
         toConfig.normalize().orderChildren();
         Configuration mergedConfig = toConfig.copy();
         recursiveMerge(fromConfig.copy(), mergedConfig, fromOverridesTo);
+        mergedConfig.orderChildren();
         return mergedConfig;
     }
 

--- a/config/src/main/java/org/switchyard/config/DOMConfiguration.java
+++ b/config/src/main/java/org/switchyard/config/DOMConfiguration.java
@@ -662,13 +662,13 @@ public class DOMConfiguration extends BaseConfiguration {
             String xsl = new StringPuller().pull("/org/switchyard/config/pretty-print.xsl", getClass());
             Transformer t = tf.newTransformer(new StreamSource(new StringReader(xsl)));
             List<OutputKey> key_list = Arrays.asList(keys);
-            if (!key_list.contains(OutputKey.OMIT_NORMALIZATION)) {
+            if (!key_list.contains(OutputKey.EXCLUDE_NORMALIZATION)) {
                 normalize();
             }
-            if (!key_list.contains(OutputKey.OMIT_ORDERING)) {
+            if (key_list.contains(OutputKey.INCLUDE_ORDERING)) {
                 orderChildren();
             }
-            if (key_list.contains(OutputKey.OMIT_XML_DECLARATION)) {
+            if (key_list.contains(OutputKey.EXCLUDE_XML_DECLARATION)) {
                 t.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");
             }
             t.transform(getSource(), new StreamResult(writer));

--- a/config/src/main/java/org/switchyard/config/OutputKey.java
+++ b/config/src/main/java/org/switchyard/config/OutputKey.java
@@ -25,13 +25,13 @@ package org.switchyard.config;
  */
 public enum OutputKey {
 
-    /** The omit-normalization hint. */
-    OMIT_NORMALIZATION,
+    /** The include-ordering hint. */
+    INCLUDE_ORDERING,
 
-    /** The omit-ordering hint. */
-    OMIT_ORDERING,
+    /** The exclude-normalization hint. */
+    EXCLUDE_NORMALIZATION,
 
-    /** The omit-xml-declaration hint. */
-    OMIT_XML_DECLARATION
+    /** The exclude-xml-declaration hint. */
+    EXCLUDE_XML_DECLARATION
 
 }

--- a/config/src/main/java/org/switchyard/config/model/Model.java
+++ b/config/src/main/java/org/switchyard/config/model/Model.java
@@ -70,6 +70,12 @@ public interface Model {
     public Validation validateModel();
 
     /**
+     * Asserts that this model is valid, according to the schema(s) defined in this model's descriptor.
+     * @return this model (useful for chaining)
+     */
+    public Model assertModelValid();
+
+    /**
      * Whether or not this model is valid, according to the schema(s) defined in this model's descriptor.
      * @return true if the model is valid
      */

--- a/config/src/main/java/org/switchyard/config/model/Models.java
+++ b/config/src/main/java/org/switchyard/config/model/Models.java
@@ -52,6 +52,20 @@ public final class Models {
      * @return the newly merged model
      */
     public static <M extends Model> M merge(M fromModel, M toModel, boolean fromOverridesTo) {
+        return merge(fromModel, toModel, fromOverridesTo, false);
+    }
+
+    /**
+     * Merges two models into a new model.
+     * Note: The act of merging results in fromModel and toModel to have their configurations normalized and children ordered!
+     * @param <M> the type of Model being merged
+     * @param fromModel merge from this model, optionally overriding anything in toModel
+     * @param toModel merge into a copy of this model
+     * @param fromOverridesTo whether fromModel attributes/values should override those in toModel
+     * @param validate whether the newly merged model should be validated before it is returned
+     * @return the newly merged model
+     */
+    public static <M extends Model> M merge(M fromModel, M toModel, boolean fromOverridesTo, boolean validate) {
         String from_model_cn = fromModel.getClass().getName();
         String to_model_cn = toModel.getClass().getName();
         if (!from_model_cn.equals(to_model_cn)) {
@@ -62,6 +76,10 @@ public final class Models {
         Configuration merged_model_config = Configurations.merge(from_model_config, to_model_config, fromOverridesTo);
         @SuppressWarnings("unchecked")
         M merged_model = (M)Descriptor.getMarshaller(toModel).read(merged_model_config);
+        merged_model.orderModelChildren();
+        if (validate) {
+            merged_model.assertModelValid();
+        }
         return merged_model;
     }
 

--- a/config/src/main/java/org/switchyard/config/model/Validation.java
+++ b/config/src/main/java/org/switchyard/config/model/Validation.java
@@ -23,37 +23,61 @@ package org.switchyard.config.model;
  *
  * @author David Ward &lt;<a href="mailto:dward@jboss.org">dward@jboss.org</a>&gt; (C) 2011 Red Hat Inc.
  */
-public class Validation {
+public final class Validation {
 
+    private Class<? extends Model> _modelClass;
     private boolean _valid;
     private String _message;
     private Throwable _cause;
 
     /**
      * Constructs a new Validation.
+     * @param modelClass the model class
      * @param valid whether or not the validation was a success
      */
-    public Validation(boolean valid) {
-        this(valid, null);
+    public Validation(Class<? extends Model> modelClass, boolean valid) {
+        this(modelClass, valid, null);
     }
 
     /**
      * Constructs a new Validation.
+     * @param modelClass the model class
      * @param valid whether or not the validation was a success
      * @param message the message to report
      */
-    public Validation(boolean valid, String message) {
+    public Validation(Class<? extends Model> modelClass, boolean valid, String message) {
+        _modelClass = modelClass;
         _valid = valid;
         _message = message;
     }
 
     /**
      * Constructs a new, unsuccessful Validation.
+     * @param modelClass the model class
      * @param cause the cause of the failed validation
      */
-    public Validation(Throwable cause) {
-        this(false, cause.getMessage());
+    public Validation(Class<? extends Model> modelClass, Throwable cause) {
+        this(modelClass, false, cause.getMessage());
         _cause = cause;
+    }
+
+    /**
+     * Gets the class of the model which underwent validation.
+     * @return the class of the model which underwent validation
+     */
+    public Class<? extends Model> getModelClass() {
+        return _modelClass;
+    }
+
+    /**
+     * Asserts this validation was successful.
+     * @return this Validation (useful for chaining)
+     */
+    public Validation assertValid() {
+        if (!isValid()) {
+            throw new RuntimeException("Model [" + getModelClass().getName() + "] is invalid: " + getMessage(), getCause());
+        }
+        return this;
     }
 
     /**

--- a/config/src/main/java/org/switchyard/config/model/composite/ComponentReferenceModel.java
+++ b/config/src/main/java/org/switchyard/config/model/composite/ComponentReferenceModel.java
@@ -31,11 +31,27 @@ public interface ComponentReferenceModel extends NamedModel {
     /** The "reference" name. */
     public static final String REFERENCE = "reference";
 
+    /** The "multiplicity" name. */
+    public static final String MULTIPLICITY = "multiplicity";
+
     /**
      * Gets the parent component model.
      * @return the parent component model
      */
     public ComponentModel getComponent();
+
+    /**
+     * Gets the multiplicity attribute.
+     * @return the multiplicity attribute
+     */
+    public String getMultiplicity();
+
+    /**
+     * Sets the multiplicity attribute.
+     * @param multiplicity the multiplicity attribute
+     * @return this ComponentReferenceModel (useful for chaining)
+     */
+    public ComponentReferenceModel setMultiplicity(String multiplicity);
 
     /**
      * Gets the child component reference interface model.

--- a/config/src/main/java/org/switchyard/config/model/composite/CompositeReferenceModel.java
+++ b/config/src/main/java/org/switchyard/config/model/composite/CompositeReferenceModel.java
@@ -35,6 +35,12 @@ public interface CompositeReferenceModel extends NamedModel {
     /** The "promote" name. */
     public static final String PROMOTE = "promote";
 
+    /** The "multiplicity" name. */
+    public static final String MULTIPLICITY = "multiplicity";
+
+    /** The default multiplicity (1..1). */
+    public static final String DEFAULT_MULTIPLICITY = "1..1";
+
     /**
      * Gets the parent composite model.
      * @return the parent composite model
@@ -65,6 +71,19 @@ public interface CompositeReferenceModel extends NamedModel {
      * @return this CompositeReferenceModel (useful for chaining)
      */
     public CompositeReferenceModel setPromote(String promote);
+
+    /**
+     * Gets the multiplicity attribute.
+     * @return the multiplicity attribute
+     */
+    public String getMultiplicity();
+
+    /**
+     * Sets the multiplicity attribute.
+     * @param multiplicity the multiplicity attribute
+     * @return this CompositeReferenceModel (useful for chaining)
+     */
+    public CompositeReferenceModel setMultiplicity(String multiplicity);
 
     /**
      * Gets the child binding models.

--- a/config/src/main/java/org/switchyard/config/model/composite/v1/V1ComponentReferenceModel.java
+++ b/config/src/main/java/org/switchyard/config/model/composite/v1/V1ComponentReferenceModel.java
@@ -25,10 +25,10 @@ import org.switchyard.config.Configuration;
 import org.switchyard.config.model.BaseNamedModel;
 import org.switchyard.config.model.Descriptor;
 import org.switchyard.config.model.composite.ComponentModel;
+import org.switchyard.config.model.composite.ComponentReferenceInterfaceModel;
 import org.switchyard.config.model.composite.ComponentReferenceModel;
 import org.switchyard.config.model.composite.CompositeModel;
 import org.switchyard.config.model.composite.InterfaceModel;
-import org.switchyard.config.model.composite.ComponentReferenceInterfaceModel;
 
 /**
  * A version 1 ComponentReferenceModel.
@@ -61,6 +61,23 @@ public class V1ComponentReferenceModel extends BaseNamedModel implements Compone
     @Override
     public ComponentModel getComponent() {
         return (ComponentModel)getModelParent();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getMultiplicity() {
+        return getModelAttribute(ComponentReferenceModel.MULTIPLICITY);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public ComponentReferenceModel setMultiplicity(String multiplicity) {
+        setModelAttribute(ComponentReferenceModel.MULTIPLICITY, multiplicity);
+        return this;
     }
 
     /**

--- a/config/src/main/java/org/switchyard/config/model/composite/v1/V1CompositeReferenceModel.java
+++ b/config/src/main/java/org/switchyard/config/model/composite/v1/V1CompositeReferenceModel.java
@@ -54,6 +54,7 @@ public class V1CompositeReferenceModel extends BaseNamedModel implements Composi
      */
     public V1CompositeReferenceModel() {
         super(new QName(CompositeModel.DEFAULT_NAMESPACE, CompositeReferenceModel.REFERENCE));
+        setMultiplicity(CompositeReferenceModel.DEFAULT_MULTIPLICITY);
     }
 
     /**
@@ -151,6 +152,23 @@ public class V1CompositeReferenceModel extends BaseNamedModel implements Composi
     @Override
     public CompositeReferenceModel setPromote(String promote) {
         setModelAttribute(CompositeReferenceModel.PROMOTE, promote);
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getMultiplicity() {
+        return getModelAttribute(CompositeReferenceModel.MULTIPLICITY);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public CompositeReferenceModel setMultiplicity(String multiplicity) {
+        setModelAttribute(CompositeReferenceModel.MULTIPLICITY, multiplicity);
         return this;
     }
 

--- a/config/src/main/java/org/switchyard/config/model/domain/v1/V1DomainModel.java
+++ b/config/src/main/java/org/switchyard/config/model/domain/v1/V1DomainModel.java
@@ -27,6 +27,7 @@ import org.switchyard.config.model.domain.DomainModel;
 import org.switchyard.config.model.domain.HandlersModel;
 import org.switchyard.config.model.domain.PropertiesModel;
 import org.switchyard.config.model.switchyard.SwitchYardModel;
+import org.switchyard.config.model.transform.TransformsModel;
 
 /**
  * Implementation of DomainModel : v1.
@@ -41,7 +42,7 @@ public class V1DomainModel extends BaseNamedModel implements DomainModel {
      */
     public V1DomainModel() {
         super(new QName(SwitchYardModel.DEFAULT_NAMESPACE, DomainModel.DOMAIN));
-        setModelChildrenOrder(PropertiesModel.PROPERTIES, HandlersModel.HANDLERS);
+        setModelChildrenOrder(TransformsModel.TRANSFORMS, PropertiesModel.PROPERTIES, HandlersModel.HANDLERS);
     }
 
     /**
@@ -51,7 +52,7 @@ public class V1DomainModel extends BaseNamedModel implements DomainModel {
      */
     public V1DomainModel(Configuration config, Descriptor desc) {
         super(config, desc);
-        setModelChildrenOrder(PropertiesModel.PROPERTIES, HandlersModel.HANDLERS);
+        setModelChildrenOrder(TransformsModel.TRANSFORMS, PropertiesModel.PROPERTIES, HandlersModel.HANDLERS);
     }
     
     @Override

--- a/config/src/main/java/org/switchyard/config/model/resource/v1/V1ResourceModel.java
+++ b/config/src/main/java/org/switchyard/config/model/resource/v1/V1ResourceModel.java
@@ -82,6 +82,14 @@ public class V1ResourceModel extends BaseModel implements ResourceModel {
      * {@inheritDoc}
      */
     @Override
+    public URL getLocationURL(ClassLoader loader) {
+        return BaseResource.getURL(getLocation(), loader);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public ResourceModel setLocation(String location) {
         setModelAttribute("location", location);
         return this;

--- a/config/src/test/java/org/switchyard/config/ConfigurationTests.java
+++ b/config/src/test/java/org/switchyard/config/ConfigurationTests.java
@@ -145,7 +145,7 @@ public class ConfigurationTests {
         one.setChildrenOrder("a", "b", "c");
         Configuration three = root.getFirstChild("three");
         three.setChildrenOrder("c", "b", "a");
-        String actual_xml = root.toString(); // toString() orders the children by default (but can be overridden by OutputKey.OMIT_ORDERING)
+        String actual_xml = root.orderChildren().toString();
         String expected_xml = _str_puller.pull(ORDER_CHILDREN_ORDERED_XML, getClass());
         XMLUnit.setIgnoreWhitespace(true);
         Diff diff = XMLUnit.compareXML(expected_xml, actual_xml);

--- a/config/src/test/java/org/switchyard/config/model/composite/CompositeModelTests.java
+++ b/config/src/test/java/org/switchyard/config/model/composite/CompositeModelTests.java
@@ -197,7 +197,7 @@ public class CompositeModelTests {
     @Test
     public void testValidation() throws Exception {
         CompositeModel composite = _puller.pull(COMPLETE_XML, getClass());
-        Assert.assertTrue(composite.isModelValid());
+        composite.assertModelValid();
     }
 
     @Test

--- a/config/src/test/java/org/switchyard/config/model/switchyard/SwitchYardModelTests.java
+++ b/config/src/test/java/org/switchyard/config/model/switchyard/SwitchYardModelTests.java
@@ -136,7 +136,7 @@ public class SwitchYardModelTests {
     @Test
     public void testValidation() throws Exception {
         SwitchYardModel switchyard = _puller.pull(COMPLETE_XML, getClass());
-        Assert.assertTrue(switchyard.isModelValid());
+        switchyard.assertModelValid();
     }
 
     @Test

--- a/config/src/test/resources/org/switchyard/config/model/composite/CompositeModelTests-Complete.xml
+++ b/config/src/test/resources/org/switchyard/config/model/composite/CompositeModelTests-Complete.xml
@@ -38,7 +38,7 @@ MA  02110-1301, USA.
        <service name="SimpleService">
            <interface.java interface="org.switchyard.example.m1app.SimpleService"/>
        </service>
-       <reference name="anotherService" multiplicity="1..1">
+       <reference name="anotherService">
            <interface.java interface="org.switchyard.example.m1app.AnotherService"/>
        </reference>
     </component>

--- a/config/src/test/resources/org/switchyard/config/model/composite/CompositeModelTests-Incomplete.xml
+++ b/config/src/test/resources/org/switchyard/config/model/composite/CompositeModelTests-Incomplete.xml
@@ -26,7 +26,7 @@ MA  02110-1301, USA.
        <service name="SimpleService">
            <interface.java interface="org.switchyard.example.m1app.SimpleService"/>
        </service>
-       <reference name="anotherService" multiplicity="1..1">
+       <reference name="anotherService">
            <interface.java interface="org.switchyard.example.m1app.AnotherService"/>
        </reference>
     </component>

--- a/test/src/main/java/org/switchyard/test/SwitchYardTestKit.java
+++ b/test/src/main/java/org/switchyard/test/SwitchYardTestKit.java
@@ -52,7 +52,6 @@ import org.switchyard.config.model.Scannable;
 import org.switchyard.config.model.Scanner;
 import org.switchyard.config.model.ScannerInput;
 import org.switchyard.config.model.ScannerOutput;
-import org.switchyard.config.model.Validation;
 import org.switchyard.config.model.composite.CompositeModel;
 import org.switchyard.config.model.switchyard.SwitchYardModel;
 import org.switchyard.config.model.switchyard.v1.V1SwitchYardModel;
@@ -543,10 +542,7 @@ public class SwitchYardTestKit {
         try {
             M pulledModel = new ModelPuller<M>().pull(configModel);
             if (validate) {
-                Validation v = pulledModel.validateModel();
-                if (!v.isValid()) {
-                    Assert.fail("Error validating " + modelType.getSimpleName() + ": " + v.getMessage());
-                }
+                pulledModel.assertModelValid();
             }
             return pulledModel;
         } catch (IOException e) {
@@ -658,10 +654,7 @@ public class SwitchYardTestKit {
             } else {
                 returnModel = model;
             }
-            Validation v = returnModel.validateModel();
-            if (!v.isValid()) {
-                Assert.fail("Error validating " + SwitchYardModel.class.getSimpleName() + ": " + v.getMessage());
-            }
+            returnModel.assertModelValid();
             return returnModel;
         } catch (java.io.IOException ioEx) {
             throw new SwitchYardException("Failed to read switchyard config.", ioEx);

--- a/transform/src/test/java/org/switchyard/transform/config/model/TransformModelTests.java
+++ b/transform/src/test/java/org/switchyard/transform/config/model/TransformModelTests.java
@@ -131,8 +131,7 @@ public class TransformModelTests {
     @Test
     public void testValidation() throws Exception {
         SwitchYardModel switchyard = _puller.pull(XML, getClass());
-        Assert.assertTrue(switchyard.isModelValid());
+        switchyard.assertModelValid();
     }
-
 
 }


### PR DESCRIPTION
SWITCHYARD-423: merged config is not schema valid
https://issues.jboss.org/browse/SWITCHYARD-423
This bubbled out as it exposed places in our models where we don't set the proper order according to the schemas, once validation was also enforced at the post-merge phase of the switchyard configure plugin.
