### PR TITLE
SWITCHYARD-350 fix XML validation errors in development workspace

### DIFF
--- a/config/src/main/java/org/switchyard/config/model/Descriptor.java
+++ b/config/src/main/java/org/switchyard/config/model/Descriptor.java
@@ -296,37 +296,38 @@ public final class Descriptor {
 
     private String getSchemaLocation(String namespace, String schema) {
         String schemaLocation = null;
-        if (schema != null) {
-            if (namespace != null) {
-                String location = getLocation(namespace);
-                if (location != null) {
-                    schemaLocation = location + "/" + schema;
-                    schemaLocation = schemaLocation.replaceAll("\\\\", "/").replaceAll("//", "/");
-                }
+        if (namespace != null) {
+            if (schema == null) {
+                schema = getProperty(SCHEMA, namespace);
             }
-            if (schemaLocation == null && schema.startsWith("http://")) {
-                schema = schema.substring(7);
-                int pos = schema.indexOf('/');
-                if (pos != -1) {
-                    String domain = schema.substring(0, pos);
-                    StringTokenizer st = new StringTokenizer(domain, ".");
-                    int len = st.countTokens();
-                    String[] parts = new String[len];
-                    for (int i=0; i < len; i++) {
-                        parts[(len-1)-i] = st.nextToken();
-                    }
-                    StringBuilder sb = new StringBuilder();
-                    sb.append('/');
-                    for (int i=0; i < len; i++) {
-                        sb.append(parts[i]);
-                        if (i != len-1) {
-                            sb.append('/');
-                        }
-                    }
-                    domain = sb.toString();
-                    String path = schema.substring(pos, schema.length());
-                    schemaLocation = domain + path;
+            String location = getLocation(namespace);
+            if (location != null) {
+                schemaLocation = location + "/" + schema;
+                schemaLocation = schemaLocation.replaceAll("\\\\", "/").replaceAll("//", "/");
+            }
+        }
+        if (schemaLocation == null && schema != null && schema.startsWith("http://")) {
+            schema = schema.substring(7);
+            int pos = schema.indexOf('/');
+            if (pos != -1) {
+                String domain = schema.substring(0, pos);
+                StringTokenizer st = new StringTokenizer(domain, ".");
+                int len = st.countTokens();
+                String[] parts = new String[len];
+                for (int i=0; i < len; i++) {
+                    parts[(len-1)-i] = st.nextToken();
                 }
+                StringBuilder sb = new StringBuilder();
+                sb.append('/');
+                for (int i=0; i < len; i++) {
+                    sb.append(parts[i]);
+                    if (i != len-1) {
+                        sb.append('/');
+                    }
+                }
+                domain = sb.toString();
+                String path = schema.substring(pos, schema.length());
+                schemaLocation = domain + path;
             }
         }
         return schemaLocation;

--- a/config/src/main/resources/org/switchyard/config/model/switchyard/v1/switchyard-v1.xsd
+++ b/config/src/main/resources/org/switchyard/config/model/switchyard/v1/switchyard-v1.xsd
@@ -23,8 +23,7 @@ MA  02110-1301, USA.
         xmlns:sca="http://docs.oasis-open.org/ns/opencsa/sca/200912"
         elementFormDefault="qualified">
 
-    <import namespace="http://docs.oasis-open.org/ns/opencsa/sca/200912"
-            schemaLocation="sca-1.1-cd06.xsd"/>
+    <import namespace="http://docs.oasis-open.org/ns/opencsa/sca/200912"/>
 
     <element name="switchyard" type="swyd:SwitchYardType"/>
     <complexType name="SwitchYardType">

--- a/config/src/test/resources/org/switchyard/config/model/composite/CompositeModelTests-Complete.xml
+++ b/config/src/test/resources/org/switchyard/config/model/composite/CompositeModelTests-Complete.xml
@@ -21,6 +21,8 @@ MA  02110-1301, USA.
            targetNamespace="urn:m1app:example:1.0"
            xmlns:bean="urn:switchyard-config:test-bean:1.0"
            xmlns:soap="urn:switchyard-config:test-soap:1.0"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="urn:switchyard-config:test-soap:1.0 test/soap/soap.xsd"
            name="m1app">
     <service name="M1AppService" promote="SimpleService">
        <soap:binding.soap>

--- a/config/src/test/resources/org/switchyard/config/model/composite/CompositeModelTests-Extended.xml
+++ b/config/src/test/resources/org/switchyard/config/model/composite/CompositeModelTests-Extended.xml
@@ -19,8 +19,11 @@ MA  02110-1301, USA.
 -->
 <composite xmlns="http://docs.oasis-open.org/ns/opencsa/sca/200912"
            targetNamespace="urn:bogus:example:1.0"
-           xmlns:bogus="urn:switchyard-config:test-bogus:1.0">
-    <component>
+           xmlns:bogus="urn:switchyard-config:test-bogus:1.0"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="urn:switchyard-config:test-bogus:1.0 test/bogus/bogus.xsd"
+           name="m1app">
+    <component name="component">
        <bogus:implementation.test foo="bar"/>
        <service name="SimpleService">
               <!-- no interface -->

--- a/config/src/test/resources/org/switchyard/config/model/composite/CompositeModelTests-Fragment.xml
+++ b/config/src/test/resources/org/switchyard/config/model/composite/CompositeModelTests-Fragment.xml
@@ -20,6 +20,8 @@ MA  02110-1301, USA.
 <composite xmlns="http://docs.oasis-open.org/ns/opencsa/sca/200912"
            targetNamespace="urn:m1app:example:1.0"
            xmlns:soap="urn:switchyard-config:test-soap:1.0"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="urn:switchyard-config:test-soap:1.0 test/soap/soap.xsd"
            name="m1app">
     <service name="M1AppService" promote="SimpleService">
        <soap:binding.soap>

--- a/config/src/test/resources/org/switchyard/config/model/composite/CompositeModelTests-Incomplete.xml
+++ b/config/src/test/resources/org/switchyard/config/model/composite/CompositeModelTests-Incomplete.xml
@@ -20,6 +20,8 @@ MA  02110-1301, USA.
 <composite xmlns="http://docs.oasis-open.org/ns/opencsa/sca/200912"
            targetNamespace="urn:m1app:example:1.0"
            xmlns:bean="urn:switchyard-config:test-bean:1.0"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="urn:switchyard-config:test-bean:1.0 test/bean/bean.xsd"
            name="m1app">
     <component name="SimpleService">
        <bean:implementation.bean class="org.switchyard.example.m1app.SimpleBean"/>

--- a/config/src/test/resources/org/switchyard/config/model/composite/test/bean/bean.xsd
+++ b/config/src/test/resources/org/switchyard/config/model/composite/test/bean/bean.xsd
@@ -23,8 +23,7 @@ MA  02110-1301, USA.
         xmlns:sca="http://docs.oasis-open.org/ns/opencsa/sca/200912"
         elementFormDefault="qualified">
 
-    <import namespace="http://docs.oasis-open.org/ns/opencsa/sca/200912"
-            schemaLocation="sca-1.1-cd06.xsd"/>
+    <import namespace="http://docs.oasis-open.org/ns/opencsa/sca/200912"/>
 
     <element name="implementation.bean" type="bean:BeanImplementationType" substitutionGroup="sca:implementation"/>
     <complexType name="BeanImplementationType">

--- a/config/src/test/resources/org/switchyard/config/model/composite/test/bogus/bogus.xsd
+++ b/config/src/test/resources/org/switchyard/config/model/composite/test/bogus/bogus.xsd
@@ -23,13 +23,12 @@ MA  02110-1301, USA.
         xmlns:sca="http://docs.oasis-open.org/ns/opencsa/sca/200912"
         elementFormDefault="qualified">
 
-    <import namespace="http://docs.oasis-open.org/ns/opencsa/sca/200912"
-            schemaLocation="sca-1.1-cd06.xsd"/>
+    <import namespace="http://docs.oasis-open.org/ns/opencsa/sca/200912"/>
 
-    <element name="implementation.test" type="bogus:TestImplementationType"/>
+    <element name="implementation.test" type="bogus:TestImplementationType" substitutionGroup="sca:implementation"/>
     <complexType name="TestImplementationType">
         <complexContent>
-            <extension base="sca:Binding">
+            <extension base="sca:Implementation">
                 <attribute name="foo" type="string" use="optional"/>
             </extension>
         </complexContent>

--- a/config/src/test/resources/org/switchyard/config/model/composite/test/soap/soap.xsd
+++ b/config/src/test/resources/org/switchyard/config/model/composite/test/soap/soap.xsd
@@ -23,8 +23,7 @@ MA  02110-1301, USA.
         xmlns:sca="http://docs.oasis-open.org/ns/opencsa/sca/200912"
         elementFormDefault="qualified">
 
-    <import namespace="http://docs.oasis-open.org/ns/opencsa/sca/200912"
-            schemaLocation="sca-1.1-cd06.xsd"/>
+    <import namespace="http://docs.oasis-open.org/ns/opencsa/sca/200912"/>
 
     <element name="binding.soap" type="soap:SOAPBindingType" substitutionGroup="sca:binding"/>
     <complexType name="SOAPBindingType">

--- a/config/src/test/resources/org/switchyard/config/model/switchyard/SwitchYardModelTests-Complete.xml
+++ b/config/src/test/resources/org/switchyard/config/model/switchyard/SwitchYardModelTests-Complete.xml
@@ -23,6 +23,8 @@ MA  02110-1301, USA.
             xmlns:bean="urn:switchyard-config:test-bean:1.0"
             xmlns:java="urn:switchyard-config:test-java:1.0"
             xmlns:smooks="urn:switchyard-config:test-smooks:1.0"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="urn:switchyard-config:test-soap:1.0 ../composite/test/soap/soap.xsd"
             name="m1app">
     <sca:composite name="m1app" targetNamespace="urn:m1app:example:1.0">
         <sca:service name="M1AppService" promote="SimpleService">

--- a/config/src/test/resources/org/switchyard/config/model/switchyard/SwitchYardModelTests-Fragment.xml
+++ b/config/src/test/resources/org/switchyard/config/model/switchyard/SwitchYardModelTests-Fragment.xml
@@ -20,6 +20,8 @@ MA  02110-1301, USA.
 <switchyard xmlns="urn:switchyard-config:switchyard:1.0"
             xmlns:sca="http://docs.oasis-open.org/ns/opencsa/sca/200912"
             xmlns:soap="urn:switchyard-config:test-soap:1.0"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="urn:switchyard-config:test-soap:1.0 ../composite/test/soap/soap.xsd"
             name="m1app">
     <sca:composite name="m1app" targetNamespace="urn:m1app:example:1.0">
         <sca:service name="M1AppService" promote="SimpleService">

--- a/config/src/test/resources/org/switchyard/config/model/switchyard/SwitchYardModelTests-Incomplete.xml
+++ b/config/src/test/resources/org/switchyard/config/model/switchyard/SwitchYardModelTests-Incomplete.xml
@@ -22,6 +22,8 @@ MA  02110-1301, USA.
             xmlns:bean="urn:switchyard-config:test-bean:1.0"
             xmlns:java="urn:switchyard-config:test-java:1.0"
             xmlns:smooks="urn:switchyard-config:test-smooks:1.0"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="urn:switchyard-config:test-bean:1.0 ../composite/test/bean/bean.xsd urn:switchyard-config:test-java:1.0 test/java/java.xsd urn:switchyard-config:test-smooks:1.0 test/smooks/smooks.xsd"
             name="m1app">
     <sca:composite name="m1app"  targetNamespace="urn:m1app:example:1.0">
         <sca:component name="SimpleService">

--- a/config/src/test/resources/org/switchyard/config/model/switchyard/test/java/java.xsd
+++ b/config/src/test/resources/org/switchyard/config/model/switchyard/test/java/java.xsd
@@ -23,8 +23,7 @@ MA  02110-1301, USA.
         xmlns:swyd="urn:switchyard-config:switchyard:1.0"
         elementFormDefault="qualified">
 
-    <import namespace="urn:switchyard-config:switchyard:1.0"
-            schemaLocation="switchyard-v1.xsd"/>
+    <import namespace="urn:switchyard-config:switchyard:1.0"/>
 
     <element name="transform.java" type="java:JavaTransformType" substitutionGroup="swyd:transform"/>
     <complexType name="JavaTransformType">

--- a/config/src/test/resources/org/switchyard/config/model/switchyard/test/smooks/smooks.xsd
+++ b/config/src/test/resources/org/switchyard/config/model/switchyard/test/smooks/smooks.xsd
@@ -23,8 +23,7 @@ MA  02110-1301, USA.
         xmlns:swyd="urn:switchyard-config:switchyard:1.0"
         elementFormDefault="qualified">
 
-    <import namespace="urn:switchyard-config:switchyard:1.0"
-            schemaLocation="switchyard-v1.xsd"/>
+    <import namespace="urn:switchyard-config:switchyard:1.0"/>
 
     <element name="transform.smooks" type="smooks:SmooksTransformType" substitutionGroup="swyd:transform"/>
     <complexType name="SmooksTransformType">

--- a/deploy/base/src/test/resources/org/switchyard/component/mock/config/model/v1/mock-v1.xsd
+++ b/deploy/base/src/test/resources/org/switchyard/component/mock/config/model/v1/mock-v1.xsd
@@ -23,14 +23,21 @@ MA  02110-1301, USA.
         xmlns:sca="http://docs.oasis-open.org/ns/opencsa/sca/200912"
         elementFormDefault="qualified">
 
-    <import namespace="http://docs.oasis-open.org/ns/opencsa/sca/200912"
-            schemaLocation="sca-1.1-cd06.xsd"/>
+    <import namespace="http://docs.oasis-open.org/ns/opencsa/sca/200912"/>
 
     <!-- Mock Implementation -->
     <element name="implementation.mock" type="mock:MockImplementationType" substitutionGroup="sca:implementation"/>
     <complexType name="MockImplementationType">
         <complexContent>
             <extension base="sca:Implementation"/>
+        </complexContent>
+    </complexType>
+    
+    <!-- Mock Interface -->
+    <element name="interface.mock" type="mock:MockInterfaceType" substitutionGroup="sca:interface"/>
+    <complexType name="MockInterfaceType">
+        <complexContent>
+            <extension base="sca:Interface"/>
         </complexContent>
     </complexType>
     
@@ -41,5 +48,7 @@ MA  02110-1301, USA.
             <extension base="sca:Binding"/>
         </complexContent>
     </complexType>
+
+    <element name="binding.no_activator" type="mock:MockBindingType" substitutionGroup="sca:binding"/>
 
 </schema>

--- a/deploy/base/src/test/resources/switchyard-config-activator-01.xml
+++ b/deploy/base/src/test/resources/switchyard-config-activator-01.xml
@@ -19,15 +19,17 @@ MA  02110-1301, USA.
 -->
 <switchyard xmlns="urn:switchyard-config:switchyard:1.0"
             xmlns:sca="http://docs.oasis-open.org/ns/opencsa/sca/200912"
-            xmlns:mock="urn:switchyard-component-mock:config:1.0">
+            xmlns:mock="urn:switchyard-component-mock:config:1.0"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="urn:switchyard-component-mock:config:1.0 org/switchyard/component/mock/config/model/v1/mock-v1.xsd">
     <sca:composite name="mockBinding" targetNamespace="urn:test:config-mock-binding:1.0">
-        <sca:service name="TestService">
-            <sca:binding.foo/>
+        <sca:service name="TestService" promote="TestService">
+            <mock:binding.no_activator/>
         </sca:service>
         <sca:component name="TestService">
             <mock:implementation.mock/>
             <sca:service name="TestService">
-                <sca:interface.mock/>
+                <mock:interface.mock/>
             </sca:service>
         </sca:component>
     </sca:composite>

--- a/deploy/base/src/test/resources/switchyard-config-interface-wsdl-01.xml
+++ b/deploy/base/src/test/resources/switchyard-config-interface-wsdl-01.xml
@@ -19,7 +19,9 @@ MA  02110-1301, USA.
 -->
 <switchyard xmlns="urn:switchyard-config:switchyard:1.0"
             xmlns:sca="http://docs.oasis-open.org/ns/opencsa/sca/200912"
-            xmlns:mock="urn:switchyard-component-mock:config:1.0">
+            xmlns:mock="urn:switchyard-component-mock:config:1.0"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="urn:switchyard-component-mock:config:1.0 org/switchyard/component/mock/config/model/v1/mock-v1.xsd">
     <sca:composite name="Hello" targetNamespace="urn:switchyard-interface-wsdl">
         <sca:component name="HelloService">
             <mock:implementation.mock/>

--- a/deploy/base/src/test/resources/switchyard-config-mock-01.xml
+++ b/deploy/base/src/test/resources/switchyard-config-mock-01.xml
@@ -19,15 +19,17 @@ MA  02110-1301, USA.
 -->
 <switchyard xmlns="urn:switchyard-config:switchyard:1.0"
             xmlns:sca="http://docs.oasis-open.org/ns/opencsa/sca/200912"
-            xmlns:mock="urn:switchyard-component-mock:config:1.0">
+            xmlns:mock="urn:switchyard-component-mock:config:1.0"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="urn:switchyard-component-mock:config:1.0 org/switchyard/component/mock/config/model/v1/mock-v1.xsd">
     <sca:composite name="mockBinding" targetNamespace="urn:test:config-mock-binding:1.0">
-        <sca:service name="TestService">
+        <sca:service name="TestService" promote="TestService">
             <mock:binding.mock/>
         </sca:service>
         <sca:component name="TestService">
             <mock:implementation.mock/>
             <sca:service name="TestService">
-                <sca:interface.mock/>
+                <mock:interface.mock/>
             </sca:service>
         </sca:component>
     </sca:composite>

--- a/deploy/base/src/test/resources/switchyard-config-unknown-interface.xml
+++ b/deploy/base/src/test/resources/switchyard-config-unknown-interface.xml
@@ -1,10 +1,14 @@
-<switchyard xmlns="urn:switchyard-config:switchyard:1.0" xmlns:mock="urn:switchyard-component-mock:config:1.0">
-    <composite xmlns="http://docs.oasis-open.org/ns/opencsa/sca/200912" name="orders">
+<switchyard xmlns="urn:switchyard-config:switchyard:1.0"
+            xmlns:mock="urn:switchyard-component-mock:config:1.0"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="urn:switchyard-component-mock:config:1.0 org/switchyard/component/mock/config/model/v1/mock-v1.xsd">
+
+    <composite xmlns="http://docs.oasis-open.org/ns/opencsa/sca/200912" name="orders" targetNamespace="urn:test:config-unknown-interface:1.0">
         <component name="OrderService">
+            <mock:implementation.mock/>
             <service name="OrderService">
                 <interface.java interface="org.acme.Blah"/>
             </service>
-            <mock:implementation.mock/>
         </component>
     </composite>
 </switchyard>

--- a/test/src/test/resources/hornetq-configuration.xml
+++ b/test/src/test/resources/hornetq-configuration.xml
@@ -1,6 +1,4 @@
- <configuration xmlns="urn:hornetq"
-               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-               xsi:schemaLocation="urn:hornetq http://schema/hornetq-configuration.xsd">
+ <configuration xmlns="urn:hornetq">
                
 	<paging-directory>target/data/paging</paging-directory>
 	<bindings-directory>target/data/bindings</bindings-directory>

--- a/test/src/test/resources/hornetq-jms.xml
+++ b/test/src/test/resources/hornetq-jms.xml
@@ -1,6 +1,4 @@
-<configuration xmlns="urn:hornetq"
-            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-            xsi:schemaLocation="urn:hornetq http://schema/hornetq-jms.xsd">
+<configuration xmlns="urn:hornetq">
 
    <connection-factory name="ConnectionFactory">
       <connectors>

--- a/transform/src/main/resources/org/switchyard/transform/config/model/v1/transform-v1.xsd
+++ b/transform/src/main/resources/org/switchyard/transform/config/model/v1/transform-v1.xsd
@@ -23,7 +23,7 @@ MA  02110-1301, USA.
         xmlns:trfm="urn:switchyard-config:transform:1.0"
         elementFormDefault="qualified">
 
-    <import namespace="urn:switchyard-config:switchyard:1.0" schemaLocation="http://www.smooks.org/switchyard-v1.xsd"/>
+    <import namespace="urn:switchyard-config:switchyard:1.0"/>
 
 	<element name="transform.json" type="trfm:JsonTransformType" substitutionGroup="swyd:transform" />
 	<complexType name="JsonTransformType">


### PR DESCRIPTION
remove schemaLocation attributes from schema definitions.
fixed most validation errors.
