### PR TITLE
SWITCHYARD-438: getting all ResourceTypes by extension ignores extension 

### DIFF
--- a/common/src/main/java/org/switchyard/common/io/resource/ResourceType.java
+++ b/common/src/main/java/org/switchyard/common/io/resource/ResourceType.java
@@ -327,7 +327,7 @@ public final class ResourceType implements Comparable<ResourceType> {
         if (extension != null) {
             extension = extension.toLowerCase();
             for (ResourceType type : TYPES.values()) {
-                if (type.getExtensions(false).contains(extension)) {
+                if (type.getExtensions(includeInherited).contains(extension)) {
                     types.add(type);
                 }
             }

--- a/common/src/test/java/org/switchyard/common/io/resource/ResourceTypeTests.java
+++ b/common/src/test/java/org/switchyard/common/io/resource/ResourceTypeTests.java
@@ -64,6 +64,10 @@ public class ResourceTypeTests {
         Assert.assertEquals(4, abcd.getExtensions().size());
         Assert.assertEquals(4, abcd.getExtensions(true).size());
         Assert.assertEquals(1, abcd.getExtensions(false).size());
+        Assert.assertArrayEquals(new ResourceType[]{a}, ResourceType.forExtension(".a", false));
+        Assert.assertArrayEquals(new ResourceType[]{a, ab, abcd}, ResourceType.forExtension(".a", true));
+        Assert.assertArrayEquals(new ResourceType[]{a}, ResourceType.forLocation("path/to/foo.a", false));
+        Assert.assertArrayEquals(new ResourceType[]{a, ab, abcd}, ResourceType.forLocation("path/to/foo.a", true));
     }
 
 }


### PR DESCRIPTION
SWITCHYARD-438: getting all ResourceTypes by extension ignores extension inheritance
https://issues.jboss.org/browse/SWITCHYARD-438
