### PR TITLE
SWITCHYARD-430: Model merge does not merge schemaLocation attributes

### DIFF
--- a/config/pom.xml
+++ b/config/pom.xml
@@ -61,7 +61,6 @@
         <dependency>
             <groupId>xmlunit</groupId>
             <artifactId>xmlunit</artifactId>
-            <version>1.1</version>
         </dependency>
 	</dependencies>
 </project>

--- a/config/src/test/java/org/switchyard/config/model/composite/CompositeModelTests.java
+++ b/config/src/test/java/org/switchyard/config/model/composite/CompositeModelTests.java
@@ -39,6 +39,7 @@ import org.switchyard.config.model.composite.test.soap.PortModel;
 import org.switchyard.config.model.composite.test.soap.SOAPBindingModel;
 import org.switchyard.config.model.composite.test.soap.WSDLModel;
 import org.switchyard.config.model.composite.v1.V1ComponentImplementationModel;
+import org.switchyard.config.test.xmlunit.SchemaLocationDifferenceListener;
 
 /**
  * CompositeModelTests.
@@ -77,6 +78,7 @@ public class CompositeModelTests {
         CompositeModel complete_composite = _puller.pull(COMPLETE_XML, getClass());
         XMLUnit.setIgnoreWhitespace(true);
         Diff diff = XMLUnit.compareXML(complete_composite.toString(), merged_composite.toString());
+        diff.overrideDifferenceListener(new SchemaLocationDifferenceListener());
         Assert.assertTrue(diff.toString(), diff.identical());
     }
 

--- a/config/src/test/java/org/switchyard/config/model/switchyard/SwitchYardModelTests.java
+++ b/config/src/test/java/org/switchyard/config/model/switchyard/SwitchYardModelTests.java
@@ -47,6 +47,7 @@ import org.switchyard.config.model.switchyard.test.java.JavaTransformModel;
 import org.switchyard.config.model.switchyard.test.smooks.SmooksConfigModel;
 import org.switchyard.config.model.switchyard.test.smooks.SmooksTransformModel;
 import org.switchyard.config.model.transform.TransformsModel;
+import org.switchyard.config.test.xmlunit.SchemaLocationDifferenceListener;
 
 /**
  * SwitchYardModelTests.
@@ -84,6 +85,7 @@ public class SwitchYardModelTests {
         XMLUnit.setIgnoreWhitespace(true);
         SwitchYardModel complete_switchyard = _puller.pull(COMPLETE_XML, getClass());
         Diff diff = XMLUnit.compareXML(complete_switchyard.toString(), merged_switchyard.toString());
+        diff.overrideDifferenceListener(new SchemaLocationDifferenceListener());
         Assert.assertTrue(diff.toString(), diff.identical());
     }
 

--- a/config/src/test/java/org/switchyard/config/test/xmlunit/SchemaLocationDifferenceListener.java
+++ b/config/src/test/java/org/switchyard/config/test/xmlunit/SchemaLocationDifferenceListener.java
@@ -1,0 +1,75 @@
+/* 
+ * JBoss, Home of Professional Open Source 
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved. 
+ * See the copyright.txt in the distribution for a 
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use, 
+ * modify, copy, or redistribute it subject to the terms and conditions 
+ * of the GNU Lesser General Public License, v. 2.1. 
+ * This program is distributed in the hope that it will be useful, but WITHOUT A 
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details. 
+ * You should have received a copy of the GNU Lesser General Public License, 
+ * v.2.1 along with this distribution; if not, write to the Free Software 
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, 
+ * MA  02110-1301, USA.
+ */
+package org.switchyard.config.test.xmlunit;
+
+import java.util.StringTokenizer;
+
+import org.custommonkey.xmlunit.Difference;
+import org.custommonkey.xmlunit.DifferenceConstants;
+import org.custommonkey.xmlunit.DifferenceListener;
+import org.custommonkey.xmlunit.NodeDetail;
+import org.switchyard.common.lang.Strings;
+import org.w3c.dom.Node;
+
+/**
+ * Helps compare the xsi:schemaLocation attribute, who's potentially non-standard whitespace in between parts can cause problems.
+ *
+ * @author David Ward &lt;<a href="mailto:dward@jboss.org">dward@jboss.org</a>&gt; (C) 2011 Red Hat Inc.
+ */
+public class SchemaLocationDifferenceListener implements DifferenceListener {
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int differenceFound(Difference diff) {
+        if (diff.getId() == DifferenceConstants.SCHEMA_LOCATION_ID) {
+            String control = reduceWhitespace(diff.getControlNodeDetail());
+            String test = reduceWhitespace(diff.getTestNodeDetail());
+            if ((control == null && test == null) || (control != null && control.equals(test))) {
+                return RETURN_IGNORE_DIFFERENCE_NODES_IDENTICAL;
+            }
+        }
+        return RETURN_ACCEPT_DIFFERENCE;
+    }
+
+    private String reduceWhitespace(NodeDetail nd) {
+        String value = nd.getValue();
+        if (value != null) {
+            StringBuilder sb = new StringBuilder();
+            StringTokenizer st = new StringTokenizer(value);
+            while (st.hasMoreTokens()) {
+                sb.append(st.nextToken());
+                if (st.hasMoreTokens()) {
+                    sb.append(' ');
+                }
+            }
+            value = Strings.trimToNull(sb.toString());
+        }
+        return value;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void skippedComparison(Node control, Node test) {
+    }
+
+}

--- a/config/src/test/resources/org/switchyard/config/model/composite/CompositeModelTests-Complete.xml
+++ b/config/src/test/resources/org/switchyard/config/model/composite/CompositeModelTests-Complete.xml
@@ -22,7 +22,9 @@ MA  02110-1301, USA.
            xmlns:bean="urn:switchyard-config:test-bean:1.0"
            xmlns:soap="urn:switchyard-config:test-soap:1.0"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-           xsi:schemaLocation="urn:switchyard-config:test-soap:1.0 test/soap/soap.xsd"
+           xsi:schemaLocation="
+               urn:switchyard-config:test-bean:1.0 test/bean/bean.xsd
+               urn:switchyard-config:test-soap:1.0 test/soap/soap.xsd"
            name="m1app">
     <service name="M1AppService" promote="SimpleService">
        <soap:binding.soap>

--- a/config/src/test/resources/org/switchyard/config/model/switchyard/SwitchYardModelTests-Complete.xml
+++ b/config/src/test/resources/org/switchyard/config/model/switchyard/SwitchYardModelTests-Complete.xml
@@ -19,12 +19,16 @@ MA  02110-1301, USA.
 -->
 <switchyard xmlns="urn:switchyard-config:switchyard:1.0"
             xmlns:sca="http://docs.oasis-open.org/ns/opencsa/sca/200912"
-            xmlns:soap="urn:switchyard-config:test-soap:1.0"
             xmlns:bean="urn:switchyard-config:test-bean:1.0"
             xmlns:java="urn:switchyard-config:test-java:1.0"
             xmlns:smooks="urn:switchyard-config:test-smooks:1.0"
+            xmlns:soap="urn:switchyard-config:test-soap:1.0"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-            xsi:schemaLocation="urn:switchyard-config:test-soap:1.0 ../composite/test/soap/soap.xsd"
+            xsi:schemaLocation="
+                   urn:switchyard-config:test-bean:1.0 ../composite/test/bean/bean.xsd
+                   urn:switchyard-config:test-java:1.0 test/java/java.xsd
+                   urn:switchyard-config:test-smooks:1.0 test/smooks/smooks.xsd
+                   urn:switchyard-config:test-soap:1.0 ../composite/test/soap/soap.xsd"
             name="m1app">
     <sca:composite name="m1app" targetNamespace="urn:m1app:example:1.0">
         <sca:service name="M1AppService" promote="SimpleService">

--- a/config/src/test/resources/org/switchyard/config/model/switchyard/SwitchYardModelTests-Incomplete.xml
+++ b/config/src/test/resources/org/switchyard/config/model/switchyard/SwitchYardModelTests-Incomplete.xml
@@ -23,7 +23,10 @@ MA  02110-1301, USA.
             xmlns:java="urn:switchyard-config:test-java:1.0"
             xmlns:smooks="urn:switchyard-config:test-smooks:1.0"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-            xsi:schemaLocation="urn:switchyard-config:test-bean:1.0 ../composite/test/bean/bean.xsd urn:switchyard-config:test-java:1.0 test/java/java.xsd urn:switchyard-config:test-smooks:1.0 test/smooks/smooks.xsd"
+            xsi:schemaLocation="
+                   urn:switchyard-config:test-bean:1.0 ../composite/test/bean/bean.xsd
+                   urn:switchyard-config:test-java:1.0 test/java/java.xsd
+                   urn:switchyard-config:test-smooks:1.0 test/smooks/smooks.xsd"
             name="m1app">
     <sca:composite name="m1app"  targetNamespace="urn:m1app:example:1.0">
         <sca:component name="SimpleService">

--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,13 @@
       <optional>true</optional>
     </dependency>
     <dependency>
+      <groupId>xmlunit</groupId>
+      <artifactId>xmlunit</artifactId>
+      <version>${xmlunit.version}</version>
+      <scope>test</scope>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
       <groupId>org.switchyard</groupId>
       <artifactId>switchyard-build</artifactId>
     </dependency>

--- a/tools/maven/plugins/switchyard/pom.xml
+++ b/tools/maven/plugins/switchyard/pom.xml
@@ -65,7 +65,6 @@
         <dependency>
             <groupId>xmlunit</groupId>
             <artifactId>xmlunit</artifactId>
-            <version>1.1</version>
         </dependency>
 		<dependency>
 			<groupId>org.switchyard</groupId>

--- a/transform/pom.xml
+++ b/transform/pom.xml
@@ -76,7 +76,6 @@
         <dependency>
             <groupId>xmlunit</groupId>
             <artifactId>xmlunit</artifactId>
-            <version>1.1</version>
             <scope>test</scope>
         </dependency>
      	<dependency>


### PR DESCRIPTION
SWITCHYARD-430: Model merge does not merge schemaLocation attributes
https://issues.jboss.org/browse/SWITCHYARD-430
