### PR TITLE
SWITCHYARD-448 "Incorrect message type used in SwitchYard producer when composite-level interface is specified"

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -34,7 +34,6 @@
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	
-	<groupId>org.switchyard</groupId>
 	<artifactId>switchyard-api</artifactId>
 	
 	<packaging>jar</packaging>
@@ -45,6 +44,10 @@
 	
 	<dependencies>
 		<!-- internal dependencies -->
+		<dependency>
+			<groupId>org.switchyard</groupId>
+			<artifactId>switchyard-common</artifactId>
+		</dependency>
 		<!-- N/A -->
 		<!-- external dependencies -->
 		<dependency>

--- a/api/src/main/java/org/switchyard/metadata/java/JavaService.java
+++ b/api/src/main/java/org/switchyard/metadata/java/JavaService.java
@@ -28,6 +28,7 @@ import javax.xml.namespace.QName;
 
 import org.switchyard.annotations.DefaultType;
 import org.switchyard.annotations.OperationTypes;
+import org.switchyard.common.type.Classes;
 import org.switchyard.exception.SwitchYardException;
 import org.switchyard.metadata.BaseService;
 import org.switchyard.metadata.InOnlyOperation;
@@ -152,7 +153,29 @@ public final class JavaService extends BaseService {
             }
         }
     }
-
+    
+    /**
+     * Tries to parse the passed in {@link QName} and load the class of that
+     * type.
+     * 
+     * @param type The {@link QName} of the Java type to parse 
+     * @return Class<?> The Java class type or null if the {@link QName} passed in was null,
+     * or if the passed in type {@link QName} does not have the {@value #TYPE_PREFIX}
+     */
+    public static Class<?> parseType(final QName type) {
+        if (type == null) {
+            return null;
+        }
+        
+        final String localPart = type.getLocalPart();
+        int indexOf = localPart.indexOf(':');
+        if (indexOf != -1) {
+            return Classes.forName(localPart.substring(indexOf + 1));
+        } else {
+            return null;
+        }
+    }
+    
     private final static class OperationTypeQNames {
 
         private Method _operationMethod;

--- a/api/src/test/java/org/switchyard/metadata/JavaServiceTest.java
+++ b/api/src/test/java/org/switchyard/metadata/JavaServiceTest.java
@@ -108,6 +108,26 @@ public class JavaServiceTest {
         testOperationTypes("op3", service, QName.valueOf("java:java.lang.String"), QName.valueOf("java:java.lang.String"), QName.valueOf("C"));
         testOperationTypes("op4", service, QName.valueOf("java:java.lang.String"), QName.valueOf("java:java.lang.String"), null);
     }
+    
+    @Test
+    public void testParseType() {
+        final QName intType = new QName("java:java.lang.Integer");
+        final Class<?> intClass = JavaService.parseType(intType);
+        Assert.assertEquals(Integer.class, intClass);
+    }
+    
+    @Test
+    public void testParseTypeNull() {
+        final Class<?> intClass = JavaService.parseType(null);
+        Assert.assertEquals(null, intClass);
+    }
+    
+    @Test
+    public void testParseTypeMissingJavaPrefix() {
+        final QName missingPrefix = new QName("java.lang.Integer");
+        final Class<?> intClass = JavaService.parseType(missingPrefix);
+        Assert.assertEquals(null, intClass);
+    }
 
     private void testOperationTypes(String opName, JavaService service, QName in, QName out, QName fault) {
         ServiceOperation operation = service.getOperation(opName);


### PR DESCRIPTION
For the api module, this involved addning a helper method to JavaService to parse a qname and return the java type.
