### PR TITLE
SWITCHYARD-508

### DIFF
--- a/tools/forge/common/pom.xml
+++ b/tools/forge/common/pom.xml
@@ -17,11 +17,13 @@
       <groupId>org.jboss.forge</groupId>
       <artifactId>forge-shell-api</artifactId>
       <version>${version.forge}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.jboss.forge</groupId>
-      <artifactId>forge-project-model-maven</artifactId>
+      <artifactId>forge-maven-api</artifactId>
       <version>${version.forge}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.switchyard</groupId>

--- a/tools/forge/plugin/pom.xml
+++ b/tools/forge/plugin/pom.xml
@@ -17,11 +17,13 @@
       <groupId>org.jboss.forge</groupId>
       <artifactId>forge-shell-api</artifactId>
       <version>${version.forge}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.jboss.forge</groupId>
-      <artifactId>forge-project-model-maven</artifactId>
+      <artifactId>forge-maven-api</artifactId>
       <version>${version.forge}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.switchyard</groupId>
@@ -30,6 +32,21 @@
     <dependency>
       <groupId>org.switchyard</groupId>
       <artifactId>switchyard-forge-common</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.xalan</groupId>
+      <artifactId>xalan</artifactId>
+      <version>2.7.1-1.jbossorg</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.xalan</groupId>
+      <artifactId>serializer</artifactId>
+      <version>2.7.1-1.jbossorg</version>
+    </dependency>
+    <dependency>
+      <groupId>javax.activation</groupId>
+      <artifactId>activation</artifactId>
+      <version>1.1.1</version>
     </dependency>
   </dependencies>
   <build>
@@ -63,6 +80,17 @@
           </execution>
         </executions>
       </plugin>
+     <plugin>
+       <groupId>org.apache.maven.plugins</groupId>
+       <artifactId>maven-jar-plugin</artifactId>
+       <configuration>
+          <archive>
+             <manifestEntries>
+                <Dependencies>org.apache.xalan, log4j</Dependencies>
+             </manifestEntries>
+          </archive>
+       </configuration>
+     </plugin>
     </plugins>
   </build>
 </project>

--- a/tools/forge/plugin/src/main/resources/META-INF/services/javax.xml.transform.TransformerFactory
+++ b/tools/forge/plugin/src/main/resources/META-INF/services/javax.xml.transform.TransformerFactory
@@ -1,0 +1,1 @@
+org.apache.xalan.xsltc.trax.TransformerFactoryImpl


### PR DESCRIPTION
Changes to make switchyard-forge-plugin work from source-plugin build and to fix translet errors when adding a SwitchYard facet to a project.    Scoped forge dependencies to provided and added jboss versions of xalan and serializer.
