### PR TITLE
SWITCHYARD-492 Add message contents validation mechanism

### DIFF
--- a/admin/src/main/java/org/switchyard/admin/Application.java
+++ b/admin/src/main/java/org/switchyard/admin/Application.java
@@ -58,6 +58,11 @@ public interface Application {
     public List<Transformer> getTransformers();
 
     /**
+     * @return the validators provided by this application
+     */
+    public List<Validator> getValidators();
+
+    /**
      * Returns the name of the application. This will be the name specified
      * within the switchyard.xml file, if one exists. If a name is not specified
      * within the switchyard.xml file, the deployment archive name will be

--- a/admin/src/main/java/org/switchyard/admin/Validator.java
+++ b/admin/src/main/java/org/switchyard/admin/Validator.java
@@ -1,0 +1,42 @@
+/* 
+ * JBoss, Home of Professional Open Source 
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved. 
+ * See the copyright.txt in the distribution for a 
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use, 
+ * modify, copy, or redistribute it subject to the terms and conditions 
+ * of the GNU Lesser General Public License, v. 2.1. 
+ * This program is distributed in the hope that it will be useful, but WITHOUT A 
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details. 
+ * You should have received a copy of the GNU Lesser General Public License, 
+ * v.2.1 along with this distribution; if not, write to the Free Software 
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, 
+ * MA  02110-1301, USA.
+ */
+package org.switchyard.admin;
+
+import javax.xml.namespace.QName;
+
+/**
+ * Validator
+ * 
+ * Represents a data validator provided by an application.
+ * 
+ * @author <a href="mailto:tm.igarashi@gmail.com">Tomohisa Igarashi</a>
+ */
+public interface Validator {
+
+    /**
+     * @return the name of type upon which the validator acts
+     */
+    public QName getName();
+
+    /**
+     * @return the validator type (e.g. java, xml, etc.)
+     */
+    public String getType();
+
+}

--- a/admin/src/main/java/org/switchyard/admin/base/BaseApplication.java
+++ b/admin/src/main/java/org/switchyard/admin/base/BaseApplication.java
@@ -32,6 +32,7 @@ import org.switchyard.admin.Application;
 import org.switchyard.admin.ComponentService;
 import org.switchyard.admin.Service;
 import org.switchyard.admin.Transformer;
+import org.switchyard.admin.Validator;
 
 /**
  * Base implementation of Application.
@@ -43,6 +44,7 @@ public class BaseApplication implements Application {
     private Map<QName, Service> _services;
     private Map<QName, ComponentService> _componentServices;
     private List<Transformer> _transformers;
+    private List<Validator> _validators;
     
     /**
      * Create a new BaseApplication with the specified services.
@@ -70,6 +72,7 @@ public class BaseApplication implements Application {
         _services = new LinkedHashMap<QName, Service>();
         _componentServices = new LinkedHashMap<QName, ComponentService>();
         _transformers = new LinkedList<Transformer>();
+        _validators = new LinkedList<Validator>();
     }
 
     @Override
@@ -165,6 +168,20 @@ public class BaseApplication implements Application {
 
     protected void addTransformer(Transformer transformer) {
         _transformers.add(transformer);
+    }
+
+    @Override
+    public List<Validator> getValidators() {
+        return Collections.unmodifiableList(_validators);
+    }
+
+    protected void setValidators(List<Validator> validators) {
+        _validators.clear();
+        _validators.addAll(validators);
+    }
+
+    protected void addValidators(Validator validator) {
+        _validators.add(validator);
     }
 
 }

--- a/admin/src/main/java/org/switchyard/admin/base/BaseValidator.java
+++ b/admin/src/main/java/org/switchyard/admin/base/BaseValidator.java
@@ -1,0 +1,58 @@
+/* 
+ * JBoss, Home of Professional Open Source 
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved. 
+ * See the copyright.txt in the distribution for a 
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use, 
+ * modify, copy, or redistribute it subject to the terms and conditions 
+ * of the GNU Lesser General Public License, v. 2.1. 
+ * This program is distributed in the hope that it will be useful, but WITHOUT A 
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details. 
+ * You should have received a copy of the GNU Lesser General Public License, 
+ * v.2.1 along with this distribution; if not, write to the Free Software 
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, 
+ * MA  02110-1301, USA.
+ */
+package org.switchyard.admin.base;
+
+import javax.xml.namespace.QName;
+
+import org.switchyard.admin.Validator;
+
+/**
+ * BaseValidator
+ * 
+ * Base implementation for {@link Validator}.
+ * 
+ * @author <a href="mailto:tm.igarashi@gmail.com">Tomohisa Igarashi</a>
+ */
+public class BaseValidator implements Validator {
+
+    private final QName _name;
+    private final String _type;
+
+    /**
+     * Create a new BaseTransformer.
+     * 
+     * @param name the name of type
+     * @param type the implementation type (e.g. java)
+     */
+    public BaseValidator(QName name, String type) {
+        _name = name;
+        _type = type;
+    }
+
+    @Override
+    public QName getName() {
+        return _name;
+    }
+
+    @Override
+    public String getType() {
+        return _type;
+    }
+
+}

--- a/api/src/main/java/org/switchyard/Exchange.java
+++ b/api/src/main/java/org/switchyard/Exchange.java
@@ -44,6 +44,11 @@ public interface Exchange {
     String RELATES_TO = "org.switchyard.relatesTo";
 
     /**
+     * Context property name used for Message Content Type.
+     */
+    String CONTENT_TYPE = "org.switchyard.contentType";
+    
+    /**
      * Retrieves the exchange context.
      * @return the exchange context
      */

--- a/api/src/main/java/org/switchyard/ServiceDomain.java
+++ b/api/src/main/java/org/switchyard/ServiceDomain.java
@@ -27,6 +27,7 @@ import org.switchyard.metadata.ExchangeContract;
 import org.switchyard.metadata.ServiceInterface;
 import org.switchyard.policy.Policy;
 import org.switchyard.transform.TransformerRegistry;
+import org.switchyard.validate.ValidatorRegistry;
 
 /**
  * A ServiceDomain represents a collection of services with a shared set of
@@ -115,6 +116,12 @@ public interface ServiceDomain {
      */
     TransformerRegistry getTransformerRegistry();
     
+    /**
+     * Returns a references to the validator registry for this domain.
+     * @return validator registry instance
+     */
+    ValidatorRegistry getValidatorRegistry();
+
     /**
      * Returns the default handler chain for this service domain.  Handlers
      * present in this chain will execute for all message exchange activity

--- a/api/src/main/java/org/switchyard/annotations/Validator.java
+++ b/api/src/main/java/org/switchyard/annotations/Validator.java
@@ -1,0 +1,42 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+
+package org.switchyard.annotations;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * @author <a href="mailto:tm.igarashi@gmail.com">Tomohisa Igarashi</a>
+ */
+@Target({METHOD })
+@Retention(RUNTIME)
+@Documented
+public @interface Validator {
+
+    /**
+     * Validate for (QName).
+     */
+    String name() default "";
+
+}

--- a/api/src/main/java/org/switchyard/exception/DuplicateValidatorException.java
+++ b/api/src/main/java/org/switchyard/exception/DuplicateValidatorException.java
@@ -1,0 +1,52 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+
+package org.switchyard.exception;
+
+/**
+ * A DuplicateValidatorException is thrown by SwitchYard when a duplicate validator
+ * is trying to be registered for a 'name' type for which there already exists 
+ * a validator in the validator registry.
+ *
+ * @author <a href="mailto:tm.igarashi@gmail.com">Tomohisa Igarashi</a>
+ */
+public class DuplicateValidatorException extends SwitchYardException {
+
+    /**
+     * Serial version unique id.
+     */
+    private static final long serialVersionUID = -8937972965502786027L;
+
+    /**
+     * Public constructor.
+     * @param message Exception message.
+     */
+    public DuplicateValidatorException(final String message) {
+        super(message);
+    }
+
+    /**
+     * Public constructor.
+     * @param message Exception message.
+     * @param cause Throwable cause.
+     */
+    public DuplicateValidatorException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/api/src/main/java/org/switchyard/validate/BaseValidator.java
+++ b/api/src/main/java/org/switchyard/validate/BaseValidator.java
@@ -1,0 +1,93 @@
+/* 
+ * JBoss, Home of Professional Open Source 
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved. 
+ * See the copyright.txt in the distribution for a 
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use, 
+ * modify, copy, or redistribute it subject to the terms and conditions 
+ * of the GNU Lesser General Public License, v. 2.1. 
+ * This program is distributed in the hope that it will be useful, but WITHOUT A 
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details. 
+ * You should have received a copy of the GNU Lesser General Public License, 
+ * v.2.1 along with this distribution; if not, write to the Free Software 
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, 
+ * MA  02110-1301, USA.
+ */
+
+package org.switchyard.validate;
+
+import java.lang.reflect.ParameterizedType;
+
+import javax.xml.namespace.QName;
+
+import org.switchyard.metadata.java.JavaService;
+
+
+/**
+ * Base validator implementation.
+ *
+ * @param <T> Type
+ */
+public abstract class BaseValidator<T> implements Validator<T> {
+
+    private QName _name;
+
+    /**
+     * Constructor.
+     */
+    public BaseValidator() {
+        _name = JavaService.toMessageType(getType());
+    }
+
+    /**
+     * Constructor.
+     * @param name name
+     */
+    public BaseValidator(QName name) {
+        _name = name;
+    }
+
+    @Override
+    public Validator<T> setName(QName name) {
+        _name = name;
+        return this;
+    }
+
+    @Override
+    public QName getName() {
+        return _name;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public Class<T> getType() {
+        try {
+            ParameterizedType pt =
+                (ParameterizedType) getClass().getGenericSuperclass();
+
+            return (Class<T>) pt.getActualTypeArguments()[0];
+        } catch (Exception e) {
+            // Generics not specified...
+            return (Class<T>) Object.class;
+        }
+    }
+
+    @Override
+    public abstract boolean validate(T subject);
+
+    /**
+     * Get the type QName for the specified Java type.
+     * <p/>
+     * Utility method for {@link JavaService#toMessageType(Class)}.
+     *
+     * @param type The Java type.
+     * @return  The QName type.
+     */
+    protected static QName toMessageType(Class<?> type) {
+        return JavaService.toMessageType(type);
+    }
+
+}

--- a/api/src/main/java/org/switchyard/validate/Validator.java
+++ b/api/src/main/java/org/switchyard/validate/Validator.java
@@ -1,0 +1,60 @@
+/* 
+ * JBoss, Home of Professional Open Source 
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved. 
+ * See the copyright.txt in the distribution for a 
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use, 
+ * modify, copy, or redistribute it subject to the terms and conditions 
+ * of the GNU Lesser General Public License, v. 2.1. 
+ * This program is distributed in the hope that it will be useful, but WITHOUT A 
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details. 
+ * You should have received a copy of the GNU Lesser General Public License, 
+ * v.2.1 along with this distribution; if not, write to the Free Software 
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, 
+ * MA  02110-1301, USA.
+ */
+
+package org.switchyard.validate;
+
+import javax.xml.namespace.QName;
+
+/**
+ * Handles validation for message content to ensure type and structure is
+ * suitable for consumer. A Validator instance can be directly attached to
+ * an exchange or it can be registered in the ValidatorRegistry and loaded
+ * dynamically based on the message name.
+ *
+ * @param <T> Java type representing the content to be validated
+ */
+public interface Validator<T> {
+
+    /**
+     * Validates the content.
+     * <code>T</code>.
+     * @param content the content to be validated
+     * @return true if the content is valid, otherwise false
+     */
+    boolean validate(T content);
+
+    /**
+     * Set the name of the subject for validation.
+     * @param name name of the subject for validation.
+     * @return a reference to the current Validator.
+     */
+    Validator<T> setName(QName name);
+
+    /**
+     * Return the name of the subject for validation.
+     * @return from message
+     */
+    QName getName();
+
+    /**
+     * Return the Java type of the content to be validated.
+     * @return class representing the Java type for the content to be validated
+     */
+    Class<T> getType();
+}

--- a/api/src/main/java/org/switchyard/validate/ValidatorRegistry.java
+++ b/api/src/main/java/org/switchyard/validate/ValidatorRegistry.java
@@ -1,0 +1,64 @@
+/* 
+ * JBoss, Home of Professional Open Source 
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved. 
+ * See the copyright.txt in the distribution for a 
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use, 
+ * modify, copy, or redistribute it subject to the terms and conditions 
+ * of the GNU Lesser General Public License, v. 2.1. 
+ * This program is distributed in the hope that it will be useful, but WITHOUT A 
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details. 
+ * You should have received a copy of the GNU Lesser General Public License, 
+ * v.2.1 along with this distribution; if not, write to the Free Software 
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, 
+ * MA  02110-1301, USA.
+ */
+
+package org.switchyard.validate;
+
+import javax.xml.namespace.QName;
+
+/**
+ * Registry for validators.
+ */
+public interface ValidatorRegistry {
+
+    /**
+     * Add a validator.
+     * @param validator validator
+     * @return {@code this} ValidatorRegistry instance.
+     */
+    ValidatorRegistry addValidator(Validator<?> validator);
+
+    /**
+     * Add a validator.
+     * @param validator validator
+     * @param name name
+     * @return {@code this} ValidatorRegistry instance.
+     */
+    ValidatorRegistry addValidator(Validator<?> validator, QName name);
+
+    /**
+     * Remove a validator.
+     * @param validator validatort
+     * @return status of removal
+     */
+    boolean removeValidator(Validator<?> validator);
+
+    /**
+     * Does the registry have a validator for the specified types.
+     * @param name name
+     * @return True if it has a validator, otherwise false.
+     */
+    boolean hasValidator(QName name);
+
+    /**
+     * Get a validator.
+     * @param name name
+     * @return validator
+     */
+    Validator<?> getValidator(QName name);
+}

--- a/api/src/test/java/org/switchyard/validate/BaseValidatorTest.java
+++ b/api/src/test/java/org/switchyard/validate/BaseValidatorTest.java
@@ -1,0 +1,81 @@
+/* 
+ * JBoss, Home of Professional Open Source 
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved. 
+ * See the copyright.txt in the distribution for a 
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use, 
+ * modify, copy, or redistribute it subject to the terms and conditions 
+ * of the GNU Lesser General Public License, v. 2.1. 
+ * This program is distributed in the hope that it will be useful, but WITHOUT A 
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details. 
+ * You should have received a copy of the GNU Lesser General Public License, 
+ * v.2.1 along with this distribution; if not, write to the Free Software 
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, 
+ * MA  02110-1301, USA.
+ */
+
+package org.switchyard.validate;
+
+import javax.xml.namespace.QName;
+import junit.framework.Assert;
+import org.junit.Test;
+
+public class BaseValidatorTest {
+
+    @Test
+    public void testTypedValidator() throws Exception {
+        Validator<?> t = new StringValidator();
+        Assert.assertEquals(String.class, t.getType());
+    }
+    
+    @Test
+    public void testUntypedValidator() throws Exception {
+        Validator<?> t = new UntypedValidator();
+        Assert.assertEquals(Object.class, t.getType());
+    }
+    
+    @Test
+    public void testImplementsValidator() throws Exception {
+        Validator<?> t = new ImplementsValidator();
+        Assert.assertEquals(String.class, t.getType());
+    }
+}
+
+class StringValidator extends BaseValidator<String> {
+    public boolean validate(String num) {
+        return false;
+    }
+}
+
+class UntypedValidator extends BaseValidator {
+    public boolean validate(Object obj) {
+        return false;
+    }
+}
+
+class ImplementsValidator implements Validator {
+
+    @Override
+    public QName getName() {
+        return null;
+    }
+
+    @Override
+    public Class<?> getType() {
+        return String.class;
+    }
+
+    @Override
+    public Validator setName(QName name) {
+        return null;
+    }
+
+    @Override
+    public boolean validate(Object name) {
+        return false;
+    }
+    
+}

--- a/config/src/main/java/org/switchyard/config/model/domain/v1/V1DomainModel.java
+++ b/config/src/main/java/org/switchyard/config/model/domain/v1/V1DomainModel.java
@@ -28,6 +28,7 @@ import org.switchyard.config.model.domain.HandlersModel;
 import org.switchyard.config.model.domain.PropertiesModel;
 import org.switchyard.config.model.switchyard.SwitchYardModel;
 import org.switchyard.config.model.transform.TransformsModel;
+import org.switchyard.config.model.validate.ValidatesModel;
 
 /**
  * Implementation of DomainModel : v1.
@@ -42,7 +43,7 @@ public class V1DomainModel extends BaseNamedModel implements DomainModel {
      */
     public V1DomainModel() {
         super(new QName(SwitchYardModel.DEFAULT_NAMESPACE, DomainModel.DOMAIN));
-        setModelChildrenOrder(TransformsModel.TRANSFORMS, PropertiesModel.PROPERTIES, HandlersModel.HANDLERS);
+        setModelChildrenOrder(TransformsModel.TRANSFORMS, ValidatesModel.VALIDATES, PropertiesModel.PROPERTIES, HandlersModel.HANDLERS);
     }
 
     /**
@@ -52,7 +53,7 @@ public class V1DomainModel extends BaseNamedModel implements DomainModel {
      */
     public V1DomainModel(Configuration config, Descriptor desc) {
         super(config, desc);
-        setModelChildrenOrder(TransformsModel.TRANSFORMS, PropertiesModel.PROPERTIES, HandlersModel.HANDLERS);
+        setModelChildrenOrder(TransformsModel.TRANSFORMS, ValidatesModel.VALIDATES, PropertiesModel.PROPERTIES, HandlersModel.HANDLERS);
     }
     
     @Override

--- a/config/src/main/java/org/switchyard/config/model/switchyard/SwitchYardModel.java
+++ b/config/src/main/java/org/switchyard/config/model/switchyard/SwitchYardModel.java
@@ -22,6 +22,7 @@ import org.switchyard.config.model.NamedModel;
 import org.switchyard.config.model.composite.CompositeModel;
 import org.switchyard.config.model.domain.DomainModel;
 import org.switchyard.config.model.transform.TransformsModel;
+import org.switchyard.config.model.validate.ValidatesModel;
 
 /**
  * The root "switchyard" configuration model.
@@ -61,6 +62,19 @@ public interface SwitchYardModel extends NamedModel {
      * @return this SwitchYardModel (useful for chaining)
      */
     public SwitchYardModel setTransforms(TransformsModel transforms);
+
+    /**
+     * Gets the child validates model.
+     * @return the child validates model
+     */
+    public ValidatesModel getValidates();
+    
+    /**
+     * Sets the child validates model.
+     * @param validatesModel the child validates model.
+     * @return this SwitchYardModel (useful for chaining)
+     */
+    public SwitchYardModel setValidates(ValidatesModel validatesModel);
 
     /**
      * Gets the child domain model.

--- a/config/src/main/java/org/switchyard/config/model/switchyard/v1/V1SwitchYardMarshaller.java
+++ b/config/src/main/java/org/switchyard/config/model/switchyard/v1/V1SwitchYardMarshaller.java
@@ -41,6 +41,8 @@ import org.switchyard.config.model.resource.v1.V1ResourceModel;
 import org.switchyard.config.model.switchyard.SwitchYardModel;
 import org.switchyard.config.model.transform.TransformsModel;
 import org.switchyard.config.model.transform.v1.V1TransformsModel;
+import org.switchyard.config.model.validate.ValidatesModel;
+import org.switchyard.config.model.validate.v1.V1ValidatesModel;
 
 /**
  * Marshalls switchyard Models.
@@ -68,6 +70,8 @@ public class V1SwitchYardMarshaller extends BaseMarshaller {
             return new V1SwitchYardModel(config, desc);
         } else if (name.equals(TransformsModel.TRANSFORMS)) {
             return new V1TransformsModel(config, desc);
+        } else if (name.equals(ValidatesModel.VALIDATES)) {
+            return new V1ValidatesModel(config, desc);
         } else if (name.equals(PropertiesModel.PROPERTIES)) {
             return new V1PropertiesModel(config, desc);
         } else if (name.equals(PropertyModel.PROPERTY)) {

--- a/config/src/main/java/org/switchyard/config/model/switchyard/v1/V1SwitchYardModel.java
+++ b/config/src/main/java/org/switchyard/config/model/switchyard/v1/V1SwitchYardModel.java
@@ -27,6 +27,7 @@ import org.switchyard.config.model.composite.CompositeModel;
 import org.switchyard.config.model.domain.DomainModel;
 import org.switchyard.config.model.switchyard.SwitchYardModel;
 import org.switchyard.config.model.transform.TransformsModel;
+import org.switchyard.config.model.validate.ValidatesModel;
 
 /**
  * A version 1 SwitchYardModel.
@@ -37,6 +38,7 @@ public class V1SwitchYardModel extends BaseNamedModel implements SwitchYardModel
 
     private CompositeModel _composite;
     private TransformsModel _transforms;
+    private ValidatesModel _validates;
     private DomainModel _domain;
 
     /**
@@ -44,7 +46,7 @@ public class V1SwitchYardModel extends BaseNamedModel implements SwitchYardModel
      */
     public V1SwitchYardModel() {
         super(new QName(SwitchYardModel.DEFAULT_NAMESPACE, SwitchYardModel.SWITCHYARD));
-        setModelChildrenOrder(CompositeModel.COMPOSITE, TransformsModel.TRANSFORMS, DomainModel.DOMAIN);
+        setModelChildrenOrder(CompositeModel.COMPOSITE, TransformsModel.TRANSFORMS, ValidatesModel.VALIDATES, DomainModel.DOMAIN);
     }
 
     /**
@@ -54,7 +56,7 @@ public class V1SwitchYardModel extends BaseNamedModel implements SwitchYardModel
      */
     public V1SwitchYardModel(Configuration config, Descriptor desc) {
         super(config, desc);
-        setModelChildrenOrder(CompositeModel.COMPOSITE, TransformsModel.TRANSFORMS, DomainModel.DOMAIN);
+        setModelChildrenOrder(CompositeModel.COMPOSITE, TransformsModel.TRANSFORMS, ValidatesModel.VALIDATES, DomainModel.DOMAIN);
     }
 
     /**
@@ -99,6 +101,27 @@ public class V1SwitchYardModel extends BaseNamedModel implements SwitchYardModel
         return this;
     }
     
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public ValidatesModel getValidates() {
+        if (_validates == null) {
+            _validates = (ValidatesModel)getFirstChildModelStartsWith(ValidatesModel.VALIDATES);
+        }
+        return _validates;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public SwitchYardModel setValidates(ValidatesModel validatesModel) {
+        setChildModel(validatesModel);
+        _validates = validatesModel;
+        return this;
+    }
+
     /**
      * {@inheritDoc}
      */

--- a/config/src/main/java/org/switchyard/config/model/validate/ValidateModel.java
+++ b/config/src/main/java/org/switchyard/config/model/validate/ValidateModel.java
@@ -1,0 +1,60 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+package org.switchyard.config.model.validate;
+
+import javax.xml.namespace.QName;
+
+import org.switchyard.config.model.Model;
+
+/**
+ * The "validate" configuration model.
+ *
+ * @author <a href="mailto:tm.igarashi@gmail.com">Tomohisa Igarashi</a>
+ */
+public interface ValidateModel extends Model {
+
+    /** The default "validate" namespace. */
+    public static final String DEFAULT_NAMESPACE = "urn:switchyard-config:validate:1.0";
+
+    /** The "validate" name. */
+    public static final String VALIDATE = "validate";
+
+    /** The "name" name. */
+    public static final String NAME = "name";
+
+    /**
+     * Gets the parent validates model.
+     * @return the parent validates model.
+     */
+    public ValidatesModel getValidates();
+
+    /**
+     * Gets the name attribute.
+     * @return the name attribute
+     */
+    public QName getName();
+
+    /**
+     * Sets the name attribute.
+     * @param name the name attribute
+     * @return this ValidateModel (useful for chaining)
+     */
+    public ValidateModel setName(QName name);
+
+}

--- a/config/src/main/java/org/switchyard/config/model/validate/ValidatesModel.java
+++ b/config/src/main/java/org/switchyard/config/model/validate/ValidatesModel.java
@@ -1,0 +1,55 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+package org.switchyard.config.model.validate;
+
+import java.util.List;
+
+import org.switchyard.config.model.Model;
+import org.switchyard.config.model.switchyard.SwitchYardModel;
+
+/**
+ * The "validates" configuration model.
+ *
+ * @author <a href="mailto:tm.igarashi@gmail.com">Tomohisa Igarashi</a>
+ */
+public interface ValidatesModel extends Model {
+
+    /** The "validates" name. */
+    public static final String VALIDATES = "validates";
+
+    /**
+     * Gets the parent switchyard model.
+     * @return the parent switchyard model
+     */
+    public SwitchYardModel getSwitchYard();
+
+    /**
+     * Gets the child validate models.
+     * @return the child validate models
+     */
+    public List<ValidateModel> getValidates();
+
+    /**
+     * Adds a child validate model.
+     * @param validate the child validate model to add
+     * @return this ValidatesModel (useful for chaining)
+     */
+    public ValidatesModel addValidate(ValidateModel validate);
+
+}

--- a/config/src/main/java/org/switchyard/config/model/validate/v1/V1BaseValidateModel.java
+++ b/config/src/main/java/org/switchyard/config/model/validate/v1/V1BaseValidateModel.java
@@ -1,0 +1,75 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+package org.switchyard.config.model.validate.v1;
+
+import javax.xml.namespace.QName;
+
+import org.switchyard.common.xml.XMLHelper;
+import org.switchyard.config.Configuration;
+import org.switchyard.config.model.BaseTypedModel;
+import org.switchyard.config.model.Descriptor;
+import org.switchyard.config.model.switchyard.SwitchYardModel;
+import org.switchyard.config.model.validate.ValidateModel;
+import org.switchyard.config.model.validate.ValidatesModel;
+
+/**
+ * An abstract representation of a ValidateModel.
+ *
+ * @author <a href="mailto:tm.igarashi@gmail.com">Tomohisa Igarashi</a>
+ */
+public abstract class V1BaseValidateModel extends BaseTypedModel implements ValidateModel {
+
+    protected V1BaseValidateModel(String type) {
+        this(new QName(SwitchYardModel.DEFAULT_NAMESPACE, ValidateModel.VALIDATE + '.' + type));
+    }
+
+    protected V1BaseValidateModel(QName qname) {
+        super(qname);
+    }
+
+    protected V1BaseValidateModel(Configuration config, Descriptor desc) {
+        super(config, desc);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public ValidatesModel getValidates() {
+        return (ValidatesModel)getModelParent();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public QName getName() {
+        return XMLHelper.createQName(getModelAttribute(ValidateModel.NAME));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public ValidateModel setName(QName name) {
+        setModelAttribute(ValidateModel.NAME, name != null ? name.toString() : null);
+        return this;
+    }
+
+}

--- a/config/src/main/java/org/switchyard/config/model/validate/v1/V1ValidatesModel.java
+++ b/config/src/main/java/org/switchyard/config/model/validate/v1/V1ValidatesModel.java
@@ -1,0 +1,93 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+package org.switchyard.config.model.validate.v1;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import javax.xml.namespace.QName;
+
+import org.switchyard.config.Configuration;
+import org.switchyard.config.model.BaseModel;
+import org.switchyard.config.model.Descriptor;
+import org.switchyard.config.model.switchyard.SwitchYardModel;
+import org.switchyard.config.model.validate.ValidateModel;
+import org.switchyard.config.model.validate.ValidatesModel;
+
+/**
+ * A version 1 ValidatesModel.
+ *
+ * @author <a href="mailto:tm.igarashi@gmail.com">Tomohisa Igarashi</a>
+ */
+public class V1ValidatesModel extends BaseModel implements ValidatesModel {
+
+    private List<ValidateModel> _validates = new ArrayList<ValidateModel>();
+
+    /**
+     * Constructs a new V1ValidatesModel.
+     */
+    public V1ValidatesModel() {
+        super(new QName(SwitchYardModel.DEFAULT_NAMESPACE, ValidatesModel.VALIDATES));
+        setModelChildrenOrder(ValidateModel.VALIDATE);
+    }
+
+    /**
+     * Constructs a new V1ValidatesModel with the specified Configuration and Descriptor.
+     * @param config the Configuration
+     * @param desc the Descriptor
+     */
+    public V1ValidatesModel(Configuration config, Descriptor desc) {
+        super(config, desc);
+        for (Configuration validate_config : config.getChildrenStartsWith(ValidateModel.VALIDATE)) {
+            ValidateModel validate = (ValidateModel)readModel(validate_config);
+            if (validate != null) {
+                _validates.add(validate);
+            }
+        }
+        setModelChildrenOrder(ValidateModel.VALIDATE);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public SwitchYardModel getSwitchYard() {
+        return (SwitchYardModel)getModelParent();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public synchronized List<ValidateModel> getValidates() {
+        return Collections.unmodifiableList(_validates);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public synchronized ValidatesModel addValidate(ValidateModel validate) {
+        addChildModel(validate);
+        _validates.add(validate);
+        return this;
+    }
+
+}

--- a/config/src/main/resources/org/switchyard/config/model/switchyard/v1/switchyard-v1.xsd
+++ b/config/src/main/resources/org/switchyard/config/model/switchyard/v1/switchyard-v1.xsd
@@ -30,6 +30,7 @@ MA  02110-1301, USA.
         <sequence>
            <element ref="sca:composite" minOccurs="0" maxOccurs="1"/>
            <element ref="swyd:transforms" minOccurs="0" maxOccurs="1"/>
+           <element ref="swyd:validates" minOccurs="0" maxOccurs="1"/>
            <element ref="swyd:domain" minOccurs="0" maxOccurs="1"/>
         </sequence>
         <attribute name="name" type="string" use="optional"/>
@@ -74,11 +75,24 @@ MA  02110-1301, USA.
         <attribute name="from" type="string" use="required"/>
         <attribute name="to" type="string" use="required"/>
     </complexType>
+
+    <element name="validates" type="swyd:ValidatesType"/>
+    <complexType name="ValidatesType">
+        <sequence>
+            <element ref="swyd:validate" minOccurs="0" maxOccurs="unbounded"/>
+        </sequence>
+    </complexType>
+
+    <element name="validate" type="swyd:ValidateType" abstract="true"/>
+    <complexType name="ValidateType" abstract="true">
+        <attribute name="name" type="string" use="required"/>
+    </complexType>
     
     <element name="domain" type="swyd:DomainType"/>
     <complexType name="DomainType">
         <sequence>
             <element ref="swyd:transforms" minOccurs="0" maxOccurs="1"/>
+            <element ref="swyd:validates" minOccurs="0" maxOccurs="1"/>
             <element ref="swyd:properties" minOccurs="0" maxOccurs="1"/>
             <element ref="swyd:handlers" minOccurs="0" maxOccurs="1"/>
         </sequence>

--- a/config/src/test/java/org/switchyard/config/model/switchyard/test/validate/java/JavaMarshaller.java
+++ b/config/src/test/java/org/switchyard/config/model/switchyard/test/validate/java/JavaMarshaller.java
@@ -1,0 +1,51 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+
+package org.switchyard.config.model.switchyard.test.validate.java;
+
+import org.switchyard.config.Configuration;
+import org.switchyard.config.model.Descriptor;
+import org.switchyard.config.model.Model;
+import org.switchyard.config.model.switchyard.v1.V1SwitchYardMarshaller;
+import org.switchyard.config.model.validate.ValidateModel;
+
+/**
+ * JavaMarshaller.
+ *
+ * @author <a href="mailto:tm.igarashi@gmail.com">Tomohisa Igarashi</a>
+ */
+public class JavaMarshaller extends V1SwitchYardMarshaller {
+
+    private static final String VALIDATE_JAVA = ValidateModel.VALIDATE + "." + JavaValidateModel.JAVA;
+
+    public JavaMarshaller(Descriptor desc) {
+        super(desc);
+    }
+
+    @Override
+    public Model read(Configuration config) {
+        String name = config.getName();
+        Descriptor desc = getDescriptor();
+        if (name.equals(VALIDATE_JAVA)) {
+            return new JavaValidateModel(config, desc);
+        }
+        return super.read(config);
+    }
+
+}

--- a/config/src/test/java/org/switchyard/config/model/switchyard/test/validate/java/JavaValidateModel.java
+++ b/config/src/test/java/org/switchyard/config/model/switchyard/test/validate/java/JavaValidateModel.java
@@ -1,0 +1,57 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+
+package org.switchyard.config.model.switchyard.test.validate.java;
+
+import javax.xml.namespace.QName;
+
+import org.switchyard.config.Configuration;
+import org.switchyard.config.model.Descriptor;
+import org.switchyard.config.model.validate.ValidateModel;
+import org.switchyard.config.model.validate.v1.V1BaseValidateModel;
+
+/**
+ * JavaTransformModel.
+ *
+ * @author <a href="mailto:tm.igarashi@gmail.com">Tomohisa Igarashi</a>
+ */
+public class JavaValidateModel extends V1BaseValidateModel {
+
+    public static final String DEFAULT_NAMESPACE = "urn:switchyard-config:test-validate-java:1.0";
+    public static final String JAVA = "java";
+    public static final String CLASS = "class";
+
+    public JavaValidateModel() {
+        super(new QName(DEFAULT_NAMESPACE, ValidateModel.VALIDATE + '.' + JAVA));
+    }
+
+    public JavaValidateModel(Configuration config, Descriptor desc) {
+        super(config, desc);
+    }
+
+    public String getClazz() {
+        return getModelAttribute(CLASS);
+    }
+
+    public JavaValidateModel setClazz(String clazz) {
+        setModelAttribute(CLASS, clazz);
+        return this;
+    }
+
+}

--- a/config/src/test/java/org/switchyard/config/model/switchyard/test/validate/xml/XmlMarshaller.java
+++ b/config/src/test/java/org/switchyard/config/model/switchyard/test/validate/xml/XmlMarshaller.java
@@ -1,0 +1,51 @@
+/* 
+ * JBoss, Home of Professional Open Source 
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved. 
+ * See the copyright.txt in the distribution for a 
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use, 
+ * modify, copy, or redistribute it subject to the terms and conditions 
+ * of the GNU Lesser General Public License, v. 2.1. 
+ * This program is distributed in the hope that it will be useful, but WITHOUT A 
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details. 
+ * You should have received a copy of the GNU Lesser General Public License, 
+ * v.2.1 along with this distribution; if not, write to the Free Software 
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, 
+ * MA  02110-1301, USA.
+ */
+
+package org.switchyard.config.model.switchyard.test.validate.xml;
+
+import org.switchyard.config.Configuration;
+import org.switchyard.config.model.Descriptor;
+import org.switchyard.config.model.Model;
+import org.switchyard.config.model.switchyard.v1.V1SwitchYardMarshaller;
+import org.switchyard.config.model.validate.ValidateModel;
+
+/**
+ * XmlMarshaller.
+ *
+ * @author <a href="mailto:tm.igarashi@gmail.com">Tomohisa Igarashi</a>
+ */
+public class XmlMarshaller extends V1SwitchYardMarshaller {
+
+    private static final String VALIDATE_XML = ValidateModel.VALIDATE + "." + XmlValidateModel.XML;
+
+    public XmlMarshaller(Descriptor desc) {
+        super(desc);
+    }
+
+    @Override
+    public Model read(Configuration config) {
+        String name = config.getName();
+        Descriptor desc = getDescriptor();
+        if (name.equals(VALIDATE_XML)) {
+            return new XmlValidateModel(config, desc);
+        }
+        return super.read(config);
+    }
+
+}

--- a/config/src/test/java/org/switchyard/config/model/switchyard/test/validate/xml/XmlValidateModel.java
+++ b/config/src/test/java/org/switchyard/config/model/switchyard/test/validate/xml/XmlValidateModel.java
@@ -1,0 +1,78 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+
+package org.switchyard.config.model.switchyard.test.validate.xml;
+
+import javax.xml.namespace.QName;
+
+import org.switchyard.config.Configuration;
+import org.switchyard.config.model.Descriptor;
+import org.switchyard.config.model.validate.ValidateModel;
+import org.switchyard.config.model.validate.v1.V1BaseValidateModel;
+
+/**
+ * XmlValidateModel.
+ *
+ * @author <a href="mailto:tm.igarashi@gmail.com">Tomohisa Igarashi</a>
+ */
+public class XmlValidateModel extends V1BaseValidateModel {
+
+    public static final String DEFAULT_NAMESPACE = "urn:switchyard-config:test-validate-xml:1.0";
+    public static final String XML = "xml";
+    public static final String SCHEMA_TYPE = "schemaType";
+    public static final String SCHEMA_FILE = "schemaFile";
+    public static final String FAIL_ON_WARN = "failOnWarn";
+
+    public XmlValidateModel() {
+        super(new QName(DEFAULT_NAMESPACE, ValidateModel.VALIDATE + '.' + XML));
+    }
+
+    public XmlValidateModel(Configuration config, Descriptor desc) {
+        super(config, desc);
+    }
+
+    public String getSchemaType() {
+        return getModelAttribute(SCHEMA_TYPE);
+    }
+
+    public XmlValidateModel setSchemaType(String type) {
+        setModelAttribute(SCHEMA_TYPE, type);
+        return this;
+    }
+
+    public String getSchemaFile() {
+        return getModelAttribute(SCHEMA_FILE);
+    }
+
+    public XmlValidateModel setSchemaFile(String file) {
+        setModelAttribute(SCHEMA_FILE, file);
+        return this;
+    }
+
+    public boolean getFailOnWarning() {
+        String fow = getModelAttribute(FAIL_ON_WARN);
+        return Boolean.parseBoolean(fow);
+    }
+
+    public XmlValidateModel setFailOnWarning(boolean fow) {
+        setModelAttribute(FAIL_ON_WARN, Boolean.toString(fow));
+        return this;
+    }
+
+}

--- a/config/src/test/resources/org/switchyard/config/model/descriptor.properties
+++ b/config/src/test/resources/org/switchyard/config/model/descriptor.properties
@@ -39,3 +39,15 @@ smooks.namespace=urn:switchyard-config:test-smooks:1.0
 smooks.schema=smooks.xsd
 smooks.location=/org/switchyard/config/model/switchyard/test/smooks/
 smooks.marshaller=org.switchyard.config.model.switchyard.test.smooks.SmooksMarshaller
+
+validate_java.namespace=urn:switchyard-config:test-validate-java:1.0
+validate_java.schema=java.xsd
+validate_java.location=/org/switchyard/config/model/switchyard/test/validate/java/
+validate_java.marshaller=org.switchyard.config.model.switchyard.test.validate.java.JavaMarshaller
+
+validate_xml.namespace=urn:switchyard-config:test-validate-xml:1.0
+validate_xml.schema=xml.xsd
+validate_xml.location=/org/switchyard/config/model/switchyard/test/validate/xml/
+validate_xml.marshaller=org.switchyard.config.model.switchyard.test.validate.xml.XmlMarshaller
+
+

--- a/config/src/test/resources/org/switchyard/config/model/switchyard/SwitchYardModelTests-Complete.xml
+++ b/config/src/test/resources/org/switchyard/config/model/switchyard/SwitchYardModelTests-Complete.xml
@@ -23,11 +23,15 @@ MA  02110-1301, USA.
             xmlns:java="urn:switchyard-config:test-java:1.0"
             xmlns:smooks="urn:switchyard-config:test-smooks:1.0"
             xmlns:soap="urn:switchyard-config:test-soap:1.0"
+            xmlns:vjava="urn:switchyard-config:test-validate-java:1.0"
+            xmlns:vxml="urn:switchyard-config:test-validate-xml:1.0"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xsi:schemaLocation="
                    urn:switchyard-config:test-bean:1.0 ../composite/test/bean/bean.xsd
                    urn:switchyard-config:test-java:1.0 test/java/java.xsd
                    urn:switchyard-config:test-smooks:1.0 test/smooks/smooks.xsd
+                   urn:switchyard-config:test-validate-java:1.0 test/validate/java/java.xsd
+                   urn:switchyard-config:test-validate-xml:1.0 test/validate/xml/xml.xsd
                    urn:switchyard-config:test-soap:1.0 ../composite/test/soap/soap.xsd"
             name="m1app">
     <sca:composite name="m1app" targetNamespace="urn:m1app:example:1.0">
@@ -59,10 +63,17 @@ MA  02110-1301, USA.
             <smooks:config>stuff</smooks:config>
         </smooks:transform.smooks>
     </transforms>
+    <validates>
+        <vjava:validate.java name="urn:switchyard-config:test-validate-java-a:1.0" class="org.examples.validate.AValidate"/>
+        <vxml:validate.xml name="urn:switchyard-config:test-validate-xml-a:1.0" schemaType="XML_SCHEMA" schemaFile="schema.xsd"/>
+    </validates>
     <domain name="TestDomain">
         <transforms>
             <java:transform.java from="msgD" to="msgA" class="org.examples.transform.DtoATransform"/>
         </transforms>
+        <validates>
+            <vjava:validate.java name="urn:switchyard-config:test-validate-java-b:1.0" class="org.examples.validate.BValidate"/>
+        </validates>
         <properties>
             <property name="foo" value="bar"/>
             <property name="tuna" value="fish"/>

--- a/config/src/test/resources/org/switchyard/config/model/switchyard/SwitchYardModelTests-Incomplete.xml
+++ b/config/src/test/resources/org/switchyard/config/model/switchyard/SwitchYardModelTests-Incomplete.xml
@@ -22,11 +22,15 @@ MA  02110-1301, USA.
             xmlns:bean="urn:switchyard-config:test-bean:1.0"
             xmlns:java="urn:switchyard-config:test-java:1.0"
             xmlns:smooks="urn:switchyard-config:test-smooks:1.0"
+            xmlns:vjava="urn:switchyard-config:test-validate-java:1.0"
+            xmlns:vxml="urn:switchyard-config:test-validate-xml:1.0"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xsi:schemaLocation="
                    urn:switchyard-config:test-bean:1.0 ../composite/test/bean/bean.xsd
                    urn:switchyard-config:test-java:1.0 test/java/java.xsd
-                   urn:switchyard-config:test-smooks:1.0 test/smooks/smooks.xsd"
+                   urn:switchyard-config:test-smooks:1.0 test/smooks/smooks.xsd
+                   urn:switchyard-config:test-validate-java:1.0 test/validate/java/java.xsd
+                   urn:switchyard-config:test-validate-xml:1.0 test/validate/xml/xml.xsd"
             name="m1app">
     <sca:composite name="m1app"  targetNamespace="urn:m1app:example:1.0">
         <sca:component name="SimpleService">
@@ -51,10 +55,17 @@ MA  02110-1301, USA.
             <smooks:config>stuff</smooks:config>
         </smooks:transform.smooks>
     </transforms>
+    <validates>
+        <vjava:validate.java name="urn:switchyard-config:test-validate-java-a:1.0" class="org.examples.validate.AValidate"/>
+        <vxml:validate.xml name="urn:switchyard-config:test-validate-xml-a:1.0" schemaType="XML_SCHEMA" schemaFile="schema.xsd"/>
+    </validates>
     <domain name="TestDomain">
         <transforms>
             <java:transform.java from="msgD" to="msgA" class="org.examples.transform.DtoATransform"/>
         </transforms>
+        <validates>
+            <vjava:validate.java name="urn:switchyard-config:test-validate-java-b:1.0" class="org.examples.validate.BValidate"/>
+        </validates>
         <properties>
             <property name="foo" value="bar"/>
             <property name="tuna" value="fish"/>

--- a/config/src/test/resources/org/switchyard/config/model/switchyard/test/validate/java/java.xsd
+++ b/config/src/test/resources/org/switchyard/config/model/switchyard/test/validate/java/java.xsd
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+JBoss, Home of Professional Open Source
+Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+as indicated by the @authors tag. All rights reserved.
+See the copyright.txt in the distribution for a
+full listing of individual contributors.
+
+This copyrighted material is made available to anyone wishing to use,
+modify, copy, or redistribute it subject to the terms and conditions
+of the GNU Lesser General Public License, v. 2.1.
+This program is distributed in the hope that it will be useful, but WITHOUT A
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+You should have received a copy of the GNU Lesser General Public License,
+v.2.1 along with this distribution; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+MA  02110-1301, USA.
+-->
+<schema xmlns="http://www.w3.org/2001/XMLSchema"
+        targetNamespace="urn:switchyard-config:test-validate-java:1.0"
+        xmlns:vjava="urn:switchyard-config:test-validate-java:1.0"
+        xmlns:swyd="urn:switchyard-config:switchyard:1.0"
+        elementFormDefault="qualified">
+
+    <import namespace="urn:switchyard-config:switchyard:1.0"/>
+
+    <element name="validate.java" type="vjava:JavaValidateType" substitutionGroup="swyd:validate"/>
+    <complexType name="JavaValidateType">
+        <complexContent>
+            <extension base="swyd:ValidateType">
+                <attribute name="class" type="string" use="required"/>
+            </extension>
+        </complexContent>
+    </complexType>
+
+</schema>

--- a/config/src/test/resources/org/switchyard/config/model/switchyard/test/validate/xml/xml.xsd
+++ b/config/src/test/resources/org/switchyard/config/model/switchyard/test/validate/xml/xml.xsd
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+JBoss, Home of Professional Open Source
+Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+as indicated by the @authors tag. All rights reserved.
+See the copyright.txt in the distribution for a
+full listing of individual contributors.
+
+This copyrighted material is made available to anyone wishing to use,
+modify, copy, or redistribute it subject to the terms and conditions
+of the GNU Lesser General Public License, v. 2.1.
+This program is distributed in the hope that it will be useful, but WITHOUT A
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+You should have received a copy of the GNU Lesser General Public License,
+v.2.1 along with this distribution; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+MA  02110-1301, USA.
+-->
+<schema xmlns="http://www.w3.org/2001/XMLSchema"
+        targetNamespace="urn:switchyard-config:test-validate-xml:1.0"
+        xmlns:vxml="urn:switchyard-config:test-validate-xml:1.0"
+        xmlns:swyd="urn:switchyard-config:switchyard:1.0"
+        elementFormDefault="qualified">
+
+    <import namespace="urn:switchyard-config:switchyard:1.0"/>
+
+    <element name="validate.xml" type="vxml:XmlValidateType" substitutionGroup="swyd:validate"/>
+    <complexType name="XmlValidateType">
+        <complexContent>
+            <extension base="swyd:ValidateType">
+                <attribute name="schemaType" type="vxml:XmlSchemaType" use="required"/>
+                <attribute name="schemaFile" type="string" use="required"/>
+                <attribute name="failOnWarning" type="string" use="optional"/>
+            </extension>
+        </complexContent>
+    </complexType>
+
+    <simpleType name="XmlSchemaType">
+        <restriction base="string">
+            <enumeration value="DTD">
+                <annotation>
+                    <documentation xml:lang="en">
+                        DTD.
+                    </documentation>
+                </annotation>
+            </enumeration>
+            <enumeration value="XML_SCHEMA">
+                <annotation>
+                    <documentation xml:lang="en">
+                        W3C XML Schema.
+                    </documentation>
+                </annotation>
+            </enumeration>
+            <enumeration value="RELAX_NG">
+                <annotation>
+                    <documentation xml:lang="en">
+                        RELAX NG.
+                    </documentation>
+                </annotation>
+            </enumeration>
+        </restriction>
+    </simpleType>
+
+</schema>

--- a/deploy/base/pom.xml
+++ b/deploy/base/pom.xml
@@ -63,6 +63,10 @@
             <groupId>org.switchyard</groupId>
             <artifactId>switchyard-transform</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.switchyard</groupId>
+            <artifactId>switchyard-validate</artifactId>
+        </dependency>
         <!-- N/A -->
         <!-- external dependencies -->
         <dependency>

--- a/deploy/base/src/main/java/org/switchyard/deploy/DomainProxy.java
+++ b/deploy/base/src/main/java/org/switchyard/deploy/DomainProxy.java
@@ -32,6 +32,7 @@ import org.switchyard.metadata.ExchangeContract;
 import org.switchyard.metadata.ServiceInterface;
 import org.switchyard.policy.Policy;
 import org.switchyard.transform.TransformerRegistry;
+import org.switchyard.validate.ValidatorRegistry;
 
 /**
  * Domain Proxy class.
@@ -104,6 +105,11 @@ class DomainProxy implements ServiceDomain {
     @Override
     public TransformerRegistry getTransformerRegistry() {
         return _domain.getTransformerRegistry();
+    }
+
+    @Override
+    public ValidatorRegistry getValidatorRegistry() {
+        return _domain.getValidatorRegistry();
     }
 
     @Override

--- a/deploy/base/src/main/java/org/switchyard/deploy/ServiceDomainManager.java
+++ b/deploy/base/src/main/java/org/switchyard/deploy/ServiceDomainManager.java
@@ -37,6 +37,7 @@ import org.switchyard.internal.DefaultServiceRegistry;
 import org.switchyard.internal.DomainImpl;
 import org.switchyard.internal.LocalExchangeBus;
 import org.switchyard.internal.transform.BaseTransformerRegistry;
+import org.switchyard.internal.validate.BaseValidatorRegistry;
 import org.switchyard.spi.ExchangeBus;
 import org.switchyard.spi.ServiceRegistry;
 
@@ -113,8 +114,9 @@ public class ServiceDomainManager {
         ServiceRegistry registry = getRegistry(DefaultServiceRegistry.class.getName());
         ExchangeBus endpointProvider = getEndpointProvider(LocalExchangeBus.class.getName());
         BaseTransformerRegistry transformerRegistry = new BaseTransformerRegistry();
+        BaseValidatorRegistry validatorRegistry = new BaseValidatorRegistry();
         
-        DomainImpl domain = new DomainImpl(domainName, registry, endpointProvider, transformerRegistry);
+        DomainImpl domain = new DomainImpl(domainName, registry, endpointProvider, transformerRegistry, validatorRegistry);
         // add appropriate domain config
         if (switchyardConfig != null) {
             addHandlersToDomain(domain, switchyardConfig);

--- a/deploy/base/src/main/java/org/switchyard/deploy/internal/AbstractDeployment.java
+++ b/deploy/base/src/main/java/org/switchyard/deploy/internal/AbstractDeployment.java
@@ -32,6 +32,7 @@ import org.switchyard.config.model.composite.ComponentModel;
 import org.switchyard.config.model.composite.CompositeServiceModel;
 import org.switchyard.config.model.switchyard.SwitchYardModel;
 import org.switchyard.config.model.transform.TransformsModel;
+import org.switchyard.config.model.validate.ValidatesModel;
 import org.switchyard.deploy.Activator;
 import org.switchyard.exception.SwitchYardException;
 import org.switchyard.metadata.ServiceInterface;
@@ -40,6 +41,7 @@ import org.switchyard.transform.Transformer;
 import org.switchyard.transform.TransformerRegistry;
 import org.switchyard.transform.TransformerRegistryLoader;
 import org.switchyard.transform.jaxb.internal.JAXBTransformerFactory;
+import org.switchyard.validate.ValidatorRegistryLoader;
 
 /**
  * Abstract SwitchYard application deployment.
@@ -63,6 +65,10 @@ public abstract class AbstractDeployment {
      * Transform registry loaded for the deployment.
      */
     private TransformerRegistryLoader _transformerRegistryLoader;
+    /**
+     * Validate registry loaded for the deployment.
+     */
+    private ValidatorRegistryLoader _validatorRegistryLoader;
     /**
      * SwitchYard configuration.
      */
@@ -172,6 +178,9 @@ public abstract class AbstractDeployment {
             _transformerRegistryLoader = new TransformerRegistryLoader(appServiceDomain.getTransformerRegistry());
             _transformerRegistryLoader.loadOOTBTransforms();
             
+            _validatorRegistryLoader = new ValidatorRegistryLoader(appServiceDomain.getValidatorRegistry());
+            _validatorRegistryLoader.loadOOTBValidates();
+            
             doInit(activators);
         } catch (RuntimeException e) {
             notifyListeners(new InitializationFailedNotifier(e));
@@ -257,6 +266,14 @@ public abstract class AbstractDeployment {
     }
 
     /**
+     * Get the {@link ValidatorRegistryLoader} associated with the deployment.
+     * @return The ValidatorRegistryLoader instance.
+     */
+    public ValidatorRegistryLoader getValidatorRegistryLoader() {
+        return _validatorRegistryLoader;
+    }
+
+    /**
      * Notify the implementation to initialize itself.
      * @param activators The list of SwitchYard component activators.
      */
@@ -329,6 +346,10 @@ public abstract class AbstractDeployment {
 
     protected final void fireTransformersRegistered(TransformsModel transforms) {
         notifyListeners(new TransformersRegisteredNotifier(transforms));
+    }
+
+    protected final void fireValidatorsRegistered(ValidatesModel validates) {
+        notifyListeners(new ValidatorsRegisteredNotifier(validates));
     }
 
     private void notifyListeners(DeploymentEventNotifier notifier) {
@@ -406,6 +427,18 @@ public abstract class AbstractDeployment {
 
         public void notify(DeploymentListener listener) {
             listener.transformersRegistered(AbstractDeployment.this, _transforms);
+        }
+    }
+
+    private class ValidatorsRegisteredNotifier implements DeploymentEventNotifier {
+        private ValidatesModel _validates;
+
+        protected ValidatorsRegisteredNotifier(ValidatesModel validates) {
+            _validates = validates;
+        }
+
+        public void notify(DeploymentListener listener) {
+            listener.validatorsRegistered(AbstractDeployment.this, _validates);
         }
     }
 

--- a/deploy/base/src/main/java/org/switchyard/deploy/internal/Deployment.java
+++ b/deploy/base/src/main/java/org/switchyard/deploy/internal/Deployment.java
@@ -45,6 +45,7 @@ import org.switchyard.config.model.composite.CompositeServiceModel;
 import org.switchyard.config.model.composite.InterfaceModel;
 import org.switchyard.config.model.switchyard.SwitchYardModel;
 import org.switchyard.config.model.transform.TransformsModel;
+import org.switchyard.config.model.validate.ValidatesModel;
 import org.switchyard.deploy.Activator;
 import org.switchyard.exception.SwitchYardException;
 import org.switchyard.extensions.wsdl.WSDLReaderException;
@@ -103,8 +104,9 @@ public class Deployment extends AbstractDeployment {
      */
     protected void doInit(List<Activator> activators) {
         _log.debug("Initializing deployment " + getName());
-        // create a new domain and load transformer and activator instances for lifecycle
+        // create a new domain and load transformer , validator and activator instances for lifecycle
         registerTransformers();
+        registerValidators();
         if (activators != null) {
             for (Activator activator : activators) {
                 Collection<String> activationTypes = activator.getActivationTypes();
@@ -173,6 +175,7 @@ public class Deployment extends AbstractDeployment {
         _references.clear();
         _referenceBindings.clear();
 
+        getValidatorRegistryLoader().unregisterValidators();
         getTransformerRegistryLoader().unregisterTransformers();
     }
     
@@ -212,6 +215,13 @@ public class Deployment extends AbstractDeployment {
         TransformsModel transforms = getConfig().getTransforms();
         getTransformerRegistryLoader().registerTransformers(transforms);
         fireTransformersRegistered(transforms);
+    }
+
+    private void registerValidators() {
+        _log.debug("Registering configured Validators for deployment " + getName());
+        ValidatesModel validates = getConfig().getValidates();
+        getValidatorRegistryLoader().registerValidators(validates);
+        fireValidatorsRegistered(validates);
     }
 
     private void deployReferenceBindings() {

--- a/deploy/base/src/main/java/org/switchyard/deploy/internal/DeploymentListener.java
+++ b/deploy/base/src/main/java/org/switchyard/deploy/internal/DeploymentListener.java
@@ -25,6 +25,7 @@ import javax.xml.namespace.QName;
 import org.switchyard.config.model.composite.ComponentModel;
 import org.switchyard.config.model.composite.CompositeServiceModel;
 import org.switchyard.config.model.transform.TransformsModel;
+import org.switchyard.config.model.validate.ValidatesModel;
 
 /**
  * DeploymentListener
@@ -181,5 +182,14 @@ public interface DeploymentListener extends EventListener {
      * @param transformers the transformers registered by the deployment.
      */
     public void transformersRegistered(AbstractDeployment deployment, TransformsModel transformers);
+
+    /**
+     * Notification that the deployment has registered the validators defined
+     * within it.
+     * 
+     * @param deployment the notifier
+     * @param validators the validators registered by the deployment.
+     */
+    public void validatorsRegistered(AbstractDeployment deployment, ValidatesModel validators);
 
 }

--- a/deploy/base/src/test/java/org/switchyard/deploy/ServiceDomainManagerTest.java
+++ b/deploy/base/src/test/java/org/switchyard/deploy/ServiceDomainManagerTest.java
@@ -86,6 +86,6 @@ public class ServiceDomainManagerTest {
         ServiceDomain domain = ServiceDomainManager.createDomain(
                 new QName("test"), switchyard);
         
-        Assert.assertEquals(6, domain.getHandlerChain().getHandlers().size());
+        Assert.assertEquals(8, domain.getHandlerChain().getHandlers().size());
     }
 }

--- a/deploy/base/src/test/java/org/switchyard/deploy/internal/DeploymentTest.java
+++ b/deploy/base/src/test/java/org/switchyard/deploy/internal/DeploymentTest.java
@@ -38,11 +38,14 @@ import org.switchyard.deploy.components.MockActivator;
 import org.switchyard.deploy.components.config.MockBindingModel;
 import org.switchyard.deploy.internal.transformers.ABTransformer;
 import org.switchyard.deploy.internal.transformers.CDTransformer;
+import org.switchyard.deploy.internal.validators.AValidator;
+import org.switchyard.deploy.internal.validators.BValidator;
 import org.switchyard.exception.SwitchYardException;
 import org.switchyard.extensions.wsdl.WSDLService;
 import org.switchyard.metadata.ServiceInterface;
 import org.switchyard.metadata.ServiceOperation;
 import org.switchyard.transform.Transformer;
+import org.switchyard.validate.Validator;
 
 /**
  * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
@@ -103,6 +106,28 @@ public class DeploymentTest {
         deployment.destroy();
 
         // Check that the transformers are undeployed...
+    }
+
+    @Test
+    public void test_validate_registration() throws Exception {
+        InputStream swConfigStream = Classes.getResourceAsStream("/switchyard-config-validate-01.xml", getClass());
+        Deployment deployment = new Deployment(swConfigStream);
+        swConfigStream.close();
+
+        ServiceDomain serviceDomain = ServiceDomainManager.createDomain();
+        deployment.init(serviceDomain, ActivatorLoader.createActivators(serviceDomain));
+
+        // Check that the validators are deployed...
+        ServiceDomain domain = deployment.getDomain();
+        Validator<?> aValidator = domain.getValidatorRegistry().getValidator(new QName("A"));
+        Validator<?> bValidator = domain.getValidatorRegistry().getValidator(new QName("B"));
+        
+        Assert.assertTrue(aValidator instanceof AValidator);
+        Assert.assertTrue(bValidator instanceof BValidator);
+        
+        deployment.destroy();
+
+        // Check that the validators are undeployed...
     }
 
     @Test

--- a/deploy/base/src/test/java/org/switchyard/deploy/internal/validators/AValidator.java
+++ b/deploy/base/src/test/java/org/switchyard/deploy/internal/validators/AValidator.java
@@ -1,0 +1,39 @@
+/* 
+ * JBoss, Home of Professional Open Source 
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved. 
+ * See the copyright.txt in the distribution for a 
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use, 
+ * modify, copy, or redistribute it subject to the terms and conditions 
+ * of the GNU Lesser General Public License, v. 2.1. 
+ * This program is distributed in the hope that it will be useful, but WITHOUT A 
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details. 
+ * You should have received a copy of the GNU Lesser General Public License, 
+ * v.2.1 along with this distribution; if not, write to the Free Software 
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, 
+ * MA  02110-1301, USA.
+ */
+
+package org.switchyard.deploy.internal.validators;
+
+import javax.xml.namespace.QName;
+
+import org.switchyard.validate.BaseValidator;
+
+/**
+ * @author <a href="mailto:tm.igarashi@gmail.com">Tomohisa Igarashi</a>
+ */
+public class AValidator extends BaseValidator {
+
+    public AValidator() {
+        super(new QName("A"));
+    }
+
+    @Override
+    public boolean validate(Object obj) {
+        return obj != null;
+    }
+}

--- a/deploy/base/src/test/java/org/switchyard/deploy/internal/validators/BValidator.java
+++ b/deploy/base/src/test/java/org/switchyard/deploy/internal/validators/BValidator.java
@@ -1,0 +1,39 @@
+/* 
+ * JBoss, Home of Professional Open Source 
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved. 
+ * See the copyright.txt in the distribution for a 
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use, 
+ * modify, copy, or redistribute it subject to the terms and conditions 
+ * of the GNU Lesser General Public License, v. 2.1. 
+ * This program is distributed in the hope that it will be useful, but WITHOUT A 
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details. 
+ * You should have received a copy of the GNU Lesser General Public License, 
+ * v.2.1 along with this distribution; if not, write to the Free Software 
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, 
+ * MA  02110-1301, USA.
+ */
+
+package org.switchyard.deploy.internal.validators;
+
+import org.switchyard.validate.BaseValidator;
+
+import javax.xml.namespace.QName;
+
+/**
+ * @author <a href="mailto:tm.igarashi@gmail.com">Tomohisa Igarashi</a>
+ */
+public class BValidator extends BaseValidator {
+
+    public BValidator() {
+        super(new QName("B"));
+    }
+
+    @Override
+    public boolean validate(Object obj) {
+        return obj != null;
+    }
+}

--- a/deploy/base/src/test/resources/switchyard-config-validate-01.xml
+++ b/deploy/base/src/test/resources/switchyard-config-validate-01.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+JBoss, Home of Professional Open Source
+Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+as indicated by the @authors tag. All rights reserved.
+See the copyright.txt in the distribution for a
+full listing of individual contributors.
+
+This copyrighted material is made available to anyone wishing to use,
+modify, copy, or redistribute it subject to the terms and conditions
+of the GNU Lesser General Public License, v. 2.1.
+This program is distributed in the hope that it will be useful, but WITHOUT A
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+You should have received a copy of the GNU Lesser General Public License,
+v.2.1 along with this distribution; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+MA  02110-1301, USA.
+-->
+<switchyard xmlns="urn:switchyard-config:switchyard:1.0">
+    <validates xmlns:vldt="urn:switchyard-config:validate:1.0">
+        <vldt:validate.java name="A" class="org.switchyard.deploy.internal.validators.AValidator"/>
+        <vldt:validate.java name="B" class="org.switchyard.deploy.internal.validators.BValidator"/>
+    </validates>
+</switchyard>

--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,7 @@
     <module>api</module>
     <module>extensions/wsdl</module>
     <module>transform</module>
+    <module>validate</module>
     <module>runtime</module>
     <module>admin</module>
     <module>bus/hornetq</module>
@@ -199,6 +200,11 @@
       <dependency>
         <groupId>org.switchyard</groupId>
         <artifactId>switchyard-transform</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.switchyard</groupId>
+        <artifactId>switchyard-validate</artifactId>
         <version>${project.version}</version>
       </dependency>
       <dependency>

--- a/runtime/src/main/java/org/switchyard/handlers/TransformHandler.java
+++ b/runtime/src/main/java/org/switchyard/handlers/TransformHandler.java
@@ -28,6 +28,7 @@ import org.apache.log4j.Logger;
 import org.switchyard.BaseHandler;
 import org.switchyard.Exchange;
 import org.switchyard.HandlerException;
+import org.switchyard.Scope;
 import org.switchyard.internal.transform.BaseTransformerRegistry;
 import org.switchyard.transform.TransformSequence;
 import org.switchyard.transform.Transformer;
@@ -86,6 +87,9 @@ public class TransformHandler extends BaseHandler {
 
             throw new HandlerException("Transformations not applied.  Required payload type of '" + expectedPayloadType + "'.  Actual payload type is '" + actualPayloadType + "'.  You must define and register a Transformer to transform between these types.");
         }
+
+        // Replace the CONTENT_TYPE property to indicate current content type after transform
+        exchange.getContext().setProperty(Exchange.CONTENT_TYPE, TransformSequence.getCurrentMessageType(exchange), Scope.activeScope(exchange));
     }
 
     @Override
@@ -100,6 +104,9 @@ public class TransformHandler extends BaseHandler {
                 _logger.debug("Transformations not applied.  Required payload type of '" + expectedPayloadType + "'.  Actual payload type is '" + actualPayloadType + "'.  You must define and register a Transformer to transform between these types.");
             }
         }
+
+        // Replace the CONTENT_TYPE property to indicate current content type after transform
+        exchange.getContext().setProperty(Exchange.CONTENT_TYPE, TransformSequence.getCurrentMessageType(exchange), Scope.activeScope(exchange));
     }
 }
 

--- a/runtime/src/main/java/org/switchyard/handlers/ValidateHandler.java
+++ b/runtime/src/main/java/org/switchyard/handlers/ValidateHandler.java
@@ -1,0 +1,124 @@
+/* 
+ * JBoss, Home of Professional Open Source 
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved. 
+ * See the copyright.txt in the distribution for a 
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use, 
+ * modify, copy, or redistribute it subject to the terms and conditions 
+ * of the GNU Lesser General Public License, v. 2.1. 
+ * This program is distributed in the hope that it will be useful, but WITHOUT A 
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details. 
+ * You should have received a copy of the GNU Lesser General Public License, 
+ * v.2.1 along with this distribution; if not, write to the Free Software 
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, 
+ * MA  02110-1301, USA.
+ */
+
+package org.switchyard.handlers;
+
+import javax.xml.namespace.QName;
+
+import org.apache.log4j.Logger;
+import org.switchyard.BaseHandler;
+import org.switchyard.Exchange;
+import org.switchyard.HandlerException;
+import org.switchyard.Message;
+import org.switchyard.Property;
+import org.switchyard.Scope;
+import org.switchyard.validate.Validator;
+import org.switchyard.validate.ValidatorRegistry;
+
+/**
+ * ExchangeHandler implementation used to introduce validations to the
+ * exchange handler chain.  The core runtime automatically creates a
+ * ValidateHandler and attaches it to the consumer handler chain for every
+ * exchange.  ValidateHandler can also be used in the service provider's
+ * chain by using the <code>ValidatorHandler(Validator<?>)</code>
+ * constructor.
+ *
+ */
+public class ValidateHandler extends BaseHandler {
+
+    private static final String KEY_VALIDATED_TYPE = "org.switchyard.validatedType";
+    
+    private static Logger _logger = Logger.getLogger(ValidateHandler.class);
+
+    private ValidatorRegistry _registry;
+
+    /**
+     * Create a new ValidateHandler.  The specified ValidatorRegistry will
+     * be used to locate validators for each handled exchange.
+     * @param registry validation registry to use for lookups of validator
+     */
+    public ValidateHandler(ValidatorRegistry registry) {
+        _registry = registry;
+    }
+
+    /**
+     * Validate the current message on the exchange.
+     * @param exchange exchange
+     * @throws HandlerException handler exception
+     */
+    @Override
+    public void handleMessage(Exchange exchange) throws HandlerException {
+        Validator validator = get(exchange);
+        if (validator != null) {
+            if (!applyValidator(exchange, validator)) {
+                throw new HandlerException("Validator '" + validator.getClass().getName()
+                        + "' returned false.  Check input payload matches requirements of the Validator implementation.");
+            }
+        }
+    }
+
+    @Override
+    public void handleFault(Exchange exchange) {
+        Validator validator = get(exchange);
+        if (validator != null) {
+            if (!applyValidator(exchange, validator)) {
+                _logger.warn("Validator '" + validator.getClass().getName()
+                        + "' returned false.  Check input payload matches requirements of the Validator implementation.");
+            }
+        }
+    }
+    
+    private Validator<?> get(Exchange exchange) {
+        Property contentType = exchange.getContext().getProperty(
+                Exchange.CONTENT_TYPE, Scope.activeScope(exchange));
+        Property validatedType = exchange.getContext().getProperty(
+                KEY_VALIDATED_TYPE, Scope.activeScope(exchange));
+        
+        if (contentType != null) {
+            if (validatedType != null && contentType.getValue().equals(validatedType.getValue())) {
+                // Avoid to apply same validator twice. That may occur if any transformer is not applied and
+                // then the ValidateHandler is triggered twice with same contentType in the same exchange.
+                return null;
+            }
+            return _registry.getValidator((QName)contentType.getValue());
+        } else {
+            return null;
+        }
+    }
+
+    private boolean applyValidator(Exchange exchange, Validator validator) {
+        Message message = exchange.getMessage();
+        boolean validated = false;
+        if (Message.class.isAssignableFrom(validator.getType())) {
+            validated = validator.validate(message);
+        } else {
+            validated = validator.validate(message.getContent(validator.getType()));
+        }
+
+        if (validated) {
+            if (_logger.isDebugEnabled()) {
+                _logger.debug("Validated Message (" + System.identityHashCode(message)
+                        + ") with name '" + validator.getName() + "' using validator type '" + validator.getType() + "'.");
+            }
+       }
+        exchange.getContext().setProperty(KEY_VALIDATED_TYPE, validator.getType(), Scope.activeScope(exchange));
+        return validated;
+    }
+}
+

--- a/runtime/src/main/java/org/switchyard/internal/ExchangeImpl.java
+++ b/runtime/src/main/java/org/switchyard/internal/ExchangeImpl.java
@@ -161,9 +161,11 @@ public class ExchangeImpl implements Exchange {
         // Set exchange phase
         if (_phase == null) {
             _phase = ExchangePhase.IN;
+            initInContentType();
             initInTransformSequence();
         } else if (_phase.equals(ExchangePhase.IN)) {
             _phase = ExchangePhase.OUT;
+            initOutContentType();
             initOutTransformSequence();
             // set relatesTo header on OUT context
             _context.setProperty(RELATES_TO, _context.getProperty(
@@ -297,6 +299,22 @@ public class ExchangeImpl implements Exchange {
                     from(serviceOperationOutputType).
                     to(exchangeOutputType).
                     associateWith(this, Scope.OUT);
+        }
+    }
+
+    private void initInContentType() {
+        QName exchangeInputType = _contract.getInvokerInvocationMetaData().getInputType();
+
+        if (exchangeInputType != null) {
+            _context.setProperty(Exchange.CONTENT_TYPE, exchangeInputType, Scope.IN);
+        }
+    }
+
+    private void initOutContentType() {
+        QName serviceOperationOutputType = _contract.getServiceOperation().getOutputType();
+
+        if (serviceOperationOutputType != null) {
+            _context.setProperty(Exchange.CONTENT_TYPE, serviceOperationOutputType, Scope.OUT);
         }
     }
 }

--- a/runtime/src/main/java/org/switchyard/internal/validate/BaseValidatorRegistry.java
+++ b/runtime/src/main/java/org/switchyard/internal/validate/BaseValidatorRegistry.java
@@ -1,0 +1,220 @@
+/* 
+ * JBoss, Home of Professional Open Source 
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved. 
+ * See the copyright.txt in the distribution for a 
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use, 
+ * modify, copy, or redistribute it subject to the terms and conditions 
+ * of the GNU Lesser General Public License, v. 2.1. 
+ * This program is distributed in the hope that it will be useful, but WITHOUT A 
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details. 
+ * You should have received a copy of the GNU Lesser General Public License, 
+ * v.2.1 along with this distribution; if not, write to the Free Software 
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, 
+ * MA  02110-1301, USA.
+ */
+
+package org.switchyard.internal.validate;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import javax.xml.namespace.QName;
+import org.apache.log4j.Logger;
+import org.switchyard.common.xml.QNameUtil;
+import org.switchyard.validate.Validator;
+import org.switchyard.validate.ValidatorRegistry;
+
+/**
+ * Maintains a local collection of validation instances and provides
+ * facilities to add, query, and remove validates.
+ */
+public class BaseValidatorRegistry implements ValidatorRegistry {
+
+    private static Logger _log = Logger.getLogger(BaseValidatorRegistry.class);
+
+    /**
+     * Default hash code.
+     */
+    private static final int DEFAULT_HASHCODE = 32;
+
+    private final ConcurrentHashMap<QName, Validator<?>> _validators =
+        new ConcurrentHashMap<QName, Validator<?>>();
+    private final ConcurrentHashMap<QName, Validator<?>> _fallbackValidators =
+            new ConcurrentHashMap<QName, Validator<?>>();
+
+    /**
+     * Constructor.
+     */
+    public BaseValidatorRegistry() {
+    }
+
+    /**
+     * Create a new ValidatorRegistry instance and add the list of validators
+     * to the registry.
+     * @param validators set of validators to add to registry
+     */
+    public BaseValidatorRegistry(Set<Validator<?>> validators) {
+        for (Validator<?> t : validators) {
+            addValidator(t);
+        }
+    }
+
+    @Override
+    public BaseValidatorRegistry addValidator(Validator<?> validator) {
+        _fallbackValidators.clear();
+        _validators.put(validator.getName(), validator);
+        return this;
+    }
+
+    @Override
+    public ValidatorRegistry addValidator(Validator<?> validator, QName name) {
+        _fallbackValidators.clear();
+        _validators.put(name, validator);
+        return null;
+    }
+
+    @Override
+    public Validator<?> getValidator(QName name) {
+        Validator<?> validator = _validators.get(name);
+
+        if (validator == null) {
+            validator = _fallbackValidators.get(name);
+            if (validator == null && QNameUtil.isJavaMessageType(name)) {
+                validator = getJavaFallbackValidator(name);
+                if (validator != null && _log.isDebugEnabled()) {
+                    _log.debug("Selecting fallback validator: name '" + validator.getName() + "'. Type: " + validator.getClass().getName());
+                } else if (_log.isDebugEnabled()) {
+                    _log.debug("No compatible validator registered: name '" + name + "'");
+                }
+            }
+        } else if (_log.isDebugEnabled()) {
+            _log.debug("Selecting validator: name '" + validator.getName() + "'. Type: " + validator.getClass().getName());
+        }
+        
+        return validator;
+    }
+
+    @Override
+    public boolean hasValidator(QName name) {
+        return _validators.containsKey(name);
+    }
+
+    @Override
+    public boolean removeValidator(Validator<?> validator) {
+        _fallbackValidators.clear();
+        return _validators.remove(validator.getName()) != null;
+    }
+
+    private Validator<?> getJavaFallbackValidator(QName name) {
+        Class<?> javaType = QNameUtil.toJavaMessageType(name);
+
+        if (javaType == null) {
+            return null;
+        }
+
+        Set<Map.Entry<QName,Validator<?>>> entrySet = _validators.entrySet();
+        List<JavaSourceFallbackValidator> fallbackValidates = new ArrayList<JavaSourceFallbackValidator>();
+        for (Map.Entry<QName,Validator<?>> entry : entrySet) {
+            QName nameKey = entry.getKey();
+
+            if (QNameUtil.isJavaMessageType(nameKey)) {
+                Class<?> candidateType = QNameUtil.toJavaMessageType(nameKey);
+                if (candidateType != null && candidateType.isAssignableFrom(javaType)) {
+                    fallbackValidates.add(new JavaSourceFallbackValidator(candidateType, entry.getValue()));
+                }
+            }
+        }
+
+        if (fallbackValidates.size() == 0) {
+            // No fallback...
+            return null;
+        }
+        if (fallbackValidates.size() == 1) {
+            Validator<?> fallbackValidator = fallbackValidates.get(0)._validator;
+            addFallbackValidator(fallbackValidator, name);
+            return fallbackValidator;
+        }
+
+        JavaSourceFallbackValidatorComparator comparator = new JavaSourceFallbackValidatorComparator();
+        Collections.sort(fallbackValidates, comparator);
+
+        if (_log.isDebugEnabled()) {
+            StringBuilder messageBuilder = new StringBuilder();
+
+            messageBuilder.append("Multiple possible fallback validators available:");
+            for (JavaSourceFallbackValidator t : fallbackValidates) {
+                messageBuilder.append("\n\t- name '" + t._validator.getName() + "'");
+            }
+            _log.debug(messageBuilder.toString());
+        }
+
+        // Closest super-type will be first in the list..
+        Validator<?> fallbackValidator = fallbackValidates.get(0)._validator;
+        addFallbackValidator(fallbackValidator, name);
+        return fallbackValidator;
+    }
+
+    private void addFallbackValidator(Validator<?> fallbackValidator, QName name) {
+        // Fallback validators are cached so as to save on lookup times...
+        _fallbackValidators.put(name, fallbackValidator);
+    }
+
+    /**
+     * Holder type for Fallback Validator.
+     */
+    public static class JavaSourceFallbackValidator {
+
+        private Class<?> _javaType;
+        private Validator<?> _validator;
+
+        /**
+         * Constructor.
+         * @param javaType Java type.
+         * @param validator Validator instance.
+         */
+        public JavaSourceFallbackValidator(Class<?> javaType, Validator<?> validator) {
+            this._javaType = javaType;
+            this._validator = validator;
+        }
+
+        /**
+         * Get the Java type.
+         * @return The Java type.
+         */
+        public Class<?> getJavaType() {
+            return _javaType;
+        }
+    }
+
+    /**
+     * Fallback Validator Sorter.
+     * @param <T> JavaSourceFallbackValidator.
+     */
+    @SuppressWarnings("serial")
+    public static class JavaSourceFallbackValidatorComparator<T extends JavaSourceFallbackValidator> implements Comparator<T>, Serializable {
+        @Override
+        public int compare(T t1, T t2) {
+            if (t1._javaType == t2._javaType) {
+                return 0;
+            } else if (t1._javaType.isAssignableFrom(t2._javaType)) {
+                return 1;
+            } else if (t2._javaType.isAssignableFrom(t1._javaType)) {
+                return -1;
+            } else {
+                // Unrelated types.  This means there are branches in the inheritance options,
+                // which means there are multiple possibilities, therefore it's not uniquely resolvable.
+                // Marking as equal for now...
+                return 0;
+            }
+        }
+    }
+}

--- a/runtime/src/test/java/org/switchyard/MockDomain.java
+++ b/runtime/src/test/java/org/switchyard/MockDomain.java
@@ -25,6 +25,7 @@ import org.switchyard.internal.LocalExchangeBus;
 import org.switchyard.internal.DefaultServiceRegistry;
 import org.switchyard.internal.DomainImpl;
 import org.switchyard.internal.transform.BaseTransformerRegistry;
+import org.switchyard.internal.validate.BaseValidatorRegistry;
 
 public class MockDomain extends DomainImpl {
 
@@ -35,6 +36,7 @@ public class MockDomain extends DomainImpl {
         super(DEFAULT_DOMAIN, 
                 new DefaultServiceRegistry(), 
                 new LocalExchangeBus(), 
-                new BaseTransformerRegistry());
+                new BaseTransformerRegistry(),
+                new BaseValidatorRegistry());
     }
 }

--- a/runtime/src/test/java/org/switchyard/internal/DefaultHandlerChainTest.java
+++ b/runtime/src/test/java/org/switchyard/internal/DefaultHandlerChainTest.java
@@ -53,7 +53,7 @@ public class DefaultHandlerChainTest {
         _chain.addFirst("first", badHandler);
         _chain.addLast("second", goodHandler);
         
-        _chain.handleFault(new ExchangeImpl(null, ExchangeContract.IN_ONLY, null, null));
+        _chain.handleFault(new ExchangeImpl(null, ExchangeContract.IN_ONLY, null, null, null));
         Assert.assertNotNull(goodHandler.waitForFaultMessage());
     }
     

--- a/runtime/src/test/java/org/switchyard/internal/DomainImplTest.java
+++ b/runtime/src/test/java/org/switchyard/internal/DomainImplTest.java
@@ -49,6 +49,7 @@ public class DomainImplTest {
         _domain = new DomainImpl(new QName("test"),
                 new DefaultServiceRegistry(),
                 new LocalExchangeBus(),
+                null,
                 null);
         _service = _domain.registerService(SERVICE, new MockHandler());
     }

--- a/runtime/src/test/java/org/switchyard/internal/ExchangeImplTest.java
+++ b/runtime/src/test/java/org/switchyard/internal/ExchangeImplTest.java
@@ -56,7 +56,7 @@ public class ExchangeImplTest {
     
     @Test
     public void testSendFaultOnNewExchange() {
-        Exchange exchange = new ExchangeImpl(null, ExchangeContract.IN_ONLY, null, null);
+        Exchange exchange = new ExchangeImpl(null, ExchangeContract.IN_ONLY, null, null, null);
         try {
             exchange.sendFault(exchange.createMessage());
             Assert.fail("Sending a fault on a new exchange is not allowed");
@@ -67,7 +67,7 @@ public class ExchangeImplTest {
     
     @Test
     public void testPhaseIsNullOnNewExchange() {
-        Exchange exchange = new ExchangeImpl(null, ExchangeContract.IN_ONLY, null, null);
+        Exchange exchange = new ExchangeImpl(null, ExchangeContract.IN_ONLY, null, null, null);
         Assert.assertNull(exchange.getPhase());
     }
     
@@ -134,7 +134,7 @@ public class ExchangeImplTest {
 
     @Test
     public void testNullSend() {
-        Exchange exchange = new ExchangeImpl(null, ExchangeContract.IN_ONLY, null, null);
+        Exchange exchange = new ExchangeImpl(null, ExchangeContract.IN_ONLY, null, null, null);
         try {
             exchange.send(null);
             Assert.fail("Expected IllegalArgumentException.");
@@ -145,7 +145,7 @@ public class ExchangeImplTest {
 
     @Test
     public void testNullSendFault() {
-        Exchange exchange = new ExchangeImpl(null, ExchangeContract.IN_ONLY, null, null);
+        Exchange exchange = new ExchangeImpl(null, ExchangeContract.IN_ONLY, null, null, null);
         try {
             exchange.sendFault(null);
             Assert.fail("Expected IllegalArgumentException.");

--- a/runtime/src/test/java/org/switchyard/internal/validate/BaseValidatorRegistryTest.java
+++ b/runtime/src/test/java/org/switchyard/internal/validate/BaseValidatorRegistryTest.java
@@ -1,0 +1,127 @@
+/* 
+ * JBoss, Home of Professional Open Source 
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved. 
+ * See the copyright.txt in the distribution for a 
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use, 
+ * modify, copy, or redistribute it subject to the terms and conditions 
+ * of the GNU Lesser General Public License, v. 2.1. 
+ * This program is distributed in the hope that it will be useful, but WITHOUT A 
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details. 
+ * You should have received a copy of the GNU Lesser General Public License, 
+ * v.2.1 along with this distribution; if not, write to the Free Software 
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, 
+ * MA  02110-1301, USA.
+ */
+
+package org.switchyard.internal.validate;
+
+import javax.xml.namespace.QName;
+
+import junit.framework.Assert;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.switchyard.metadata.java.JavaService;
+import org.switchyard.validate.BaseValidator;
+import org.switchyard.validate.Validator;
+import org.switchyard.validate.ValidatorRegistry;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class BaseValidatorRegistryTest {
+    
+    private ValidatorRegistry _registry;
+    
+    @Before
+    public void setUp() throws Exception {
+        _registry = new BaseValidatorRegistry();
+    }
+    
+    @Test
+    public void testAddGetValidator() {
+        final QName name = new QName("a");
+        
+        BaseValidator<String> t = 
+            new BaseValidator<String>(name) {
+                public boolean validate(String obj) {
+                    return obj != null;
+                }
+        };
+        
+        _registry.addValidator(t);
+        Assert.assertEquals(t, _registry.getValidator(name));      
+    }
+
+    @Test
+    public void test_fallbackValidatorComparator_resolvable() {
+        List<BaseValidatorRegistry.JavaSourceFallbackValidator> validatorsList = new ArrayList<BaseValidatorRegistry.JavaSourceFallbackValidator>();
+
+        // Mix them up when inserting
+        validatorsList.add(new BaseValidatorRegistry.JavaSourceFallbackValidator(C.class, null));
+        validatorsList.add(new BaseValidatorRegistry.JavaSourceFallbackValidator(E.class, null));
+        validatorsList.add(new BaseValidatorRegistry.JavaSourceFallbackValidator(D.class, null));
+        validatorsList.add(new BaseValidatorRegistry.JavaSourceFallbackValidator(A.class, null));
+        validatorsList.add(new BaseValidatorRegistry.JavaSourceFallbackValidator(B.class, null));
+
+        BaseValidatorRegistry.JavaSourceFallbackValidatorComparator comparator = new BaseValidatorRegistry.JavaSourceFallbackValidatorComparator();
+        Collections.sort(validatorsList, comparator);
+
+        // Should be sorted, sub-types first...
+        Assert.assertTrue(validatorsList.get(0).getJavaType() == E.class);
+        Assert.assertTrue(validatorsList.get(1).getJavaType() == D.class);
+        Assert.assertTrue(validatorsList.get(2).getJavaType() == C.class);
+        Assert.assertTrue(validatorsList.get(3).getJavaType() == B.class);
+        Assert.assertTrue(validatorsList.get(4).getJavaType() == A.class);
+    }
+
+    @Test
+    public void test_getFallbackValidator_resolvable() {
+        addValidator(B.class);
+        addValidator(C.class);
+
+        Validator<?> validator;
+
+        // Should return no validator...
+        validator = _registry.getValidator(getType(A.class));
+        Assert.assertNull(validator);
+
+        // Should return the C validator...
+        validator = _registry.getValidator(getType(D.class));
+        Assert.assertNotNull(validator);
+        Assert.assertEquals(getType(C.class), validator.getName());
+
+    }
+
+    private void addValidator(Class<?> type) {
+        QName name = getType(type);
+        _registry.addValidator(new TestValidator(name));
+    }
+
+    private QName getType(Class<?> type) {
+        return JavaService.toMessageType(type);
+    }
+
+    public class A {}
+    public class B extends A {}
+    public class C extends B {}
+    public class D extends C implements I {}
+    public class E extends D {}
+    public interface I {}
+
+    public class TestValidator extends BaseValidator {
+        public TestValidator(QName name) {
+            super(name);
+        }
+
+        @Override
+        public boolean validate(Object obj) {
+            return obj != null;
+        }
+    }
+}

--- a/runtime/src/test/java/org/switchyard/internal/validate/BaseValidatorTest.java
+++ b/runtime/src/test/java/org/switchyard/internal/validate/BaseValidatorTest.java
@@ -1,0 +1,83 @@
+/* 
+ * JBoss, Home of Professional Open Source 
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved. 
+ * See the copyright.txt in the distribution for a 
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use, 
+ * modify, copy, or redistribute it subject to the terms and conditions 
+ * of the GNU Lesser General Public License, v. 2.1. 
+ * This program is distributed in the hope that it will be useful, but WITHOUT A 
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details. 
+ * You should have received a copy of the GNU Lesser General Public License, 
+ * v.2.1 along with this distribution; if not, write to the Free Software 
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, 
+ * MA  02110-1301, USA.
+ */
+
+package org.switchyard.internal.validate;
+
+import javax.xml.namespace.QName;
+
+import junit.framework.Assert;
+
+import org.junit.Test;
+import org.switchyard.validate.BaseValidator;
+
+public class BaseValidatorTest {
+
+    @Test
+    public void testGetName_default_with_generics() {
+        BaseValidator<String> strv =
+            new BaseValidator<String>() {
+                public boolean validate(String obj) {
+                    return obj != null;
+                }
+        };
+
+        Assert.assertEquals("java:java.lang.String", strv.getName().toString());
+    }
+
+    @Test
+    public void testGetName_default_without_generics() {
+        // No generics...
+        BaseValidator strv =
+            new BaseValidator() {
+                public boolean validate(Object obj) {
+                    return obj != null;
+                }
+        };
+
+        Assert.assertEquals("java:java.lang.Object", strv.getName().toString());
+    }
+
+    @Test
+    public void testGetName_specified_with_generics() {
+        final QName name = new QName("string1");
+
+        BaseValidator<String> strv =
+            new BaseValidator<String>(name) {
+                public boolean validate(String obj) {
+                    return obj != null;
+                }
+        };
+
+        Assert.assertEquals(name, strv.getName());
+    }
+
+    @Test
+    public void testGetName_specified_without_generics() {
+        final QName name = new QName("string1");
+
+        BaseValidator strv =
+            new BaseValidator(name) {
+                public boolean validate(Object obj) {
+                    return obj != null;
+                }
+        };
+
+        Assert.assertEquals(name, strv.getName());
+    }
+}

--- a/runtime/src/test/java/org/switchyard/tests/ValidationTest.java
+++ b/runtime/src/test/java/org/switchyard/tests/ValidationTest.java
@@ -1,0 +1,149 @@
+/* 
+ * JBoss, Home of Professional Open Source 
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved. 
+ * See the copyright.txt in the distribution for a 
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use, 
+ * modify, copy, or redistribute it subject to the terms and conditions 
+ * of the GNU Lesser General Public License, v. 2.1. 
+ * This program is distributed in the hope that it will be useful, but WITHOUT A 
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details. 
+ * You should have received a copy of the GNU Lesser General Public License, 
+ * v.2.1 along with this distribution; if not, write to the Free Software 
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, 
+ * MA  02110-1301, USA.
+ */
+
+package org.switchyard.tests;
+
+import javax.xml.namespace.QName;
+
+import junit.framework.Assert;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.switchyard.Context;
+import org.switchyard.Exchange;
+import org.switchyard.HandlerException;
+import org.switchyard.Message;
+import org.switchyard.MockDomain;
+import org.switchyard.MockHandler;
+import org.switchyard.Scope;
+import org.switchyard.ServiceDomain;
+import org.switchyard.ServiceReference;
+import org.switchyard.exception.SwitchYardException;
+import org.switchyard.internal.DomainImpl;
+import org.switchyard.metadata.ExchangeContract;
+import org.switchyard.validate.BaseValidator;
+import org.switchyard.validate.Validator;
+
+/**
+ * Tests for exercising the ValidationHandler during message exchange.
+ */
+public class ValidationTest {
+    
+    private ServiceDomain _domain;
+
+    @Before
+    public void setUp() throws Exception {
+        _domain = new MockDomain();
+    }
+
+    /* Tests to Add :
+     * - test failed validation
+     * - test validate reply 
+     */
+    
+    /**
+     * Validation is loaded from the validator registry based on the 
+     * message name.
+     */
+    @Test
+    public void testValidationByName() throws Exception {
+        final QName serviceName = new QName("nameValidate");
+        final QName typeName = new QName("A");
+        final String input = "Hello";
+        
+        // Define the validation and register it
+        Validator<String> helloValidate = 
+                new BaseValidator<String>(typeName) {
+            public boolean validate(String obj) {
+                return obj.equals("Hello");
+            }
+        };
+        _domain.getValidatorRegistry().addValidator(helloValidate);
+
+        try {
+            // Provide the service
+            MockHandler provider = new MockHandler();
+            ServiceReference service = _domain.registerService(serviceName, provider);
+
+            // Create the exchange and invoke the service
+            Exchange exchange = _domain.createExchange(
+                    service, ExchangeContract.IN_ONLY);
+
+            // Set the message name.  NOTE: setting to the to message
+            // name will not be necessary once the service definition is available
+            // at runtime
+            Message msg = exchange.createMessage().setContent(input);
+            exchange.getContext().setProperty(Exchange.CONTENT_TYPE, typeName, Scope.IN);
+            
+            msg.setContent(input);
+            exchange.send(msg);
+
+            // wait for message and verify validation
+            provider.waitForOKMessage();
+            Assert.assertEquals(provider.getMessages().poll().getMessage().getContent(), input);
+        } finally {
+            // Must remove this validator, otherwise it's there for the following test... will be
+            // fixed once we get rid of the static service domain.
+            _domain.getValidatorRegistry().removeValidator(helloValidate);
+        }
+    }
+
+    /**
+     * Test that the ValidateHandler throws an exception if validations are not applied.
+     */
+    @Test
+    public void testValidationsFailed() throws Exception {
+        final QName serviceName = new QName("nameValidate");
+        final QName typeName = new QName("A");
+        final String input = "Hello";
+
+        // Define the validation which always fail and register it
+        Validator<String> failValidate = 
+                new BaseValidator<String>(typeName) {
+            public boolean validate(String obj) {
+                return false;
+            }
+        };
+        _domain.getValidatorRegistry().addValidator(failValidate);
+
+        // Provide the service
+        MockHandler provider = new MockHandler();
+        ServiceReference service = _domain.registerService(serviceName, provider);
+        
+        // Create the exchange and invoke the service
+        MockHandler invokerHandler = new MockHandler();
+        Exchange exchange = _domain.createExchange(
+                service, ExchangeContract.IN_ONLY, invokerHandler);
+
+        // Set the message name.  NOTE: setting to the to message
+        // name will not be necessary once the service definition is available
+        // at runtime
+        Message msg = exchange.createMessage().setContent(input);
+        exchange.getContext().setProperty(Exchange.CONTENT_TYPE, typeName, Scope.IN);
+
+        msg.setContent(input);
+
+        exchange.send(msg);
+
+        invokerHandler.waitForFaultMessage();
+        Object content = invokerHandler.getFaults().poll().getMessage().getContent();
+        Assert.assertTrue(content instanceof HandlerException);
+        Assert.assertEquals("Validator 'org.switchyard.tests.ValidationTest$2' returned false.  Check input payload matches requirements of the Validator implementation.", ((HandlerException)content).getMessage());
+    }
+}

--- a/tools/forge/plugin/src/main/java/org/switchyard/tools/forge/plugin/SwitchYardFacet.java
+++ b/tools/forge/plugin/src/main/java/org/switchyard/tools/forge/plugin/SwitchYardFacet.java
@@ -302,6 +302,7 @@ public class SwitchYardFacet extends AbstractFacet {
             +   "<param>org.switchyard.component.bpm.config.model.BPMSwitchYardScanner</param>"
             +   "<param>org.switchyard.component.rules.config.model.RulesSwitchYardScanner</param>"
             +   "<param>org.switchyard.transform.config.model.TransformSwitchYardScanner</param>"
+            +   "<param>org.switchyard.transform.config.model.ValidateSwitchYardScanner</param>"
             + "</scannerClassNames>"
             + "</configuration>";
         Xpp3Dom dom = Xpp3DomBuilder.build(new ByteArrayInputStream(pluginConfig.getBytes()),

--- a/tools/maven/archetypes/application/src/main/resources/archetype-resources/pom.xml
+++ b/tools/maven/archetypes/application/src/main/resources/archetype-resources/pom.xml
@@ -64,6 +64,7 @@
                 <param>org.switchyard.component.bean.config.model.BeanSwitchYardScanner</param>
                 <param>org.switchyard.component.camel.config.model.RouteScanner</param>
                 <param>org.switchyard.transform.config.model.TransformSwitchYardScanner</param>
+                <param>org.switchyard.validate.config.model.ValidateSwitchYardScanner</param>
             </scannerClassNames>
           </configuration>
           <executions>

--- a/tools/maven/archetypes/application/src/main/resources/archetype-resources/src/main/resources/META-INF/switchyard.xml
+++ b/tools/maven/archetypes/application/src/main/resources/archetype-resources/src/main/resources/META-INF/switchyard.xml
@@ -2,6 +2,7 @@
 <switchyard xmlns="urn:switchyard-config:switchyard:1.0"
             xmlns:swyd="urn:switchyard-config:switchyard:1.0"
             xmlns:trfm="urn:switchyard-config:transform:1.0"
+            xmlns:vldt="urn:switchyard-config:validate:1.0"
             xmlns:bean="urn:switchyard-component-bean:config:1.0"
             xmlns:soap="urn:switchyard-component-soap:config:1.0"
             xmlns:sca="http://docs.oasis-open.org/ns/opencsa/sca/200912"

--- a/validate/pom.xml
+++ b/validate/pom.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2010, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<project
+	xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    
+	<parent>
+		<groupId>org.switchyard</groupId>
+		<artifactId>switchyard-core-parent</artifactId>
+		<version>0.4.0-SNAPSHOT</version>
+		<relativePath>../pom.xml</relativePath>
+	</parent>
+	
+	<artifactId>switchyard-validate</artifactId>
+	
+	<packaging>jar</packaging>
+	<name>SwitchYard: Validate</name>
+	<description>The SwitchYard Validate library.</description>
+	<url>http://switchyard/</url>
+	
+	<dependencies>
+		<!-- internal dependencies -->
+        <dependency>
+            <groupId>org.switchyard</groupId>
+            <artifactId>switchyard-config</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.switchyard</groupId>
+            <artifactId>switchyard-api</artifactId>
+        </dependency>
+		<!-- TODO: Maybe scope this as "provided" ? -->
+        <dependency>
+            <groupId>org.milyn</groupId>
+            <artifactId>milyn-smooks-all</artifactId> 
+	        <exclusions>
+	            <exclusion>
+	              <groupId>xml-apis</groupId>
+	              <artifactId>xml-apis</artifactId>
+	            </exclusion>
+	            <exclusion>
+	              <groupId>xerces</groupId>
+	              <artifactId>xercesImpl</artifactId>
+	            </exclusion>
+	            <exclusion>
+	              <groupId>xerces</groupId>
+	              <artifactId>xmlParserAPIs</artifactId>
+	            </exclusion>
+	        </exclusions>
+        </dependency>
+		<!-- external dependencies -->
+		<dependency>
+			<groupId>log4j</groupId>
+			<artifactId>log4j</artifactId>
+            <scope>provided</scope>
+		</dependency>
+        <dependency>
+            <groupId>org.switchyard</groupId>
+            <artifactId>switchyard-runtime</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>xmlunit</groupId>
+            <artifactId>xmlunit</artifactId>
+            <scope>test</scope>
+        </dependency>
+     	<dependency>
+			<groupId>org.codehaus.jackson</groupId>
+			<artifactId>jackson-mapper-asl</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.codehaus.jackson</groupId>
+			<artifactId>jackson-core-asl</artifactId>
+		</dependency>
+	</dependencies>
+</project>

--- a/validate/src/main/java/org/switchyard/validate/ValidatorFactory.java
+++ b/validate/src/main/java/org/switchyard/validate/ValidatorFactory.java
@@ -1,0 +1,40 @@
+package org.switchyard.validate;
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+
+
+
+import org.switchyard.config.model.validate.ValidateModel;
+
+/**
+ * Validator Factory.
+ *
+ * @author <a href="mailto:tm.igarashi@gmail.com">Tomohisa Igarashi</a>
+ *
+ * @param <T> ValidatorModel type.
+ */
+public interface ValidatorFactory<T extends ValidateModel> {
+
+    /**
+     * Create a new {@link Validator} instance.
+     * @param model The Validator config model.
+     * @return The Validator instance.
+     */
+    Validator<?> newValidator(T model);
+}

--- a/validate/src/main/java/org/switchyard/validate/ValidatorFactoryClass.java
+++ b/validate/src/main/java/org/switchyard/validate/ValidatorFactoryClass.java
@@ -1,0 +1,42 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+
+package org.switchyard.validate;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Transformer factory class annotation.
+ *
+ * @author <a href="mailto:tm.igarashi@gmail.com">Tomohisa Igarashi</a>
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@Inherited
+public @interface ValidatorFactoryClass {
+
+    /**
+     * The component factory class.
+     */
+    Class<? extends ValidatorFactory> value();
+}

--- a/validate/src/main/java/org/switchyard/validate/ValidatorRegistryLoader.java
+++ b/validate/src/main/java/org/switchyard/validate/ValidatorRegistryLoader.java
@@ -1,0 +1,149 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+
+package org.switchyard.validate;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+
+import org.apache.log4j.Logger;
+import org.switchyard.common.type.Classes;
+import org.switchyard.config.model.ModelPuller;
+import org.switchyard.config.model.validate.ValidateModel;
+import org.switchyard.config.model.validate.ValidatesModel;
+import org.switchyard.exception.DuplicateValidatorException;
+import org.switchyard.exception.SwitchYardException;
+
+/**
+ * {@link ValidatorRegistry} loader class.
+ *
+ * @author <a href="mailto:tm.igarashi@gmail.com">Tomohisa Igarashi</a>
+ */
+public class ValidatorRegistryLoader {
+
+    /**
+     * Logger.
+     */
+    private static Logger _log = Logger.getLogger(ValidatorRegistryLoader.class);
+    /**
+     * Classpath location for out-of-the-box validation configurations.
+     */
+    public static final String VALIDATES_XML = "META-INF/switchyard/validates.xml";
+
+    /**
+     * Validators
+     */
+    private List<Validator> _validators = new LinkedList<Validator>();
+    /**
+     * The registry instance into which the validates were loaded.
+     */
+    private ValidatorRegistry _validatorRegistry;
+
+    /**
+     * Public constructor.
+     * @param validatorRegistry The registry instance.
+     */
+    public ValidatorRegistryLoader(ValidatorRegistry validatorRegistry) {
+        if (validatorRegistry == null) {
+            throw new IllegalArgumentException("null 'validatorRegistry' argument.");
+        }
+        this._validatorRegistry = validatorRegistry;
+    }
+
+    /**
+     * Register a set of validators in the validate registry associated with this deployment.
+     * @param validates The validates model.
+     * @throws DuplicateValidatorException an existing validator has already been registered for the from and to types
+     */
+    public void registerValidators(ValidatesModel validates) throws DuplicateValidatorException {
+        if (validates == null) {
+            return;
+        }
+
+        try {
+            for (ValidateModel validateModel : validates.getValidates()) {
+                Collection<Validator<?>> validators = ValidatorUtil.newValidators(validateModel);
+
+                for (Validator<?> validator : validators) {
+                    if (_validatorRegistry.hasValidator(validator.getName())) {
+                        Validator<?> registeredValidator = _validatorRegistry.getValidator(validator.getName());
+                        throw new DuplicateValidatorException("Failed to register Validator '" + toDescription(validator)
+                                + "'.  A Transformer for these types is already registered: '"
+                                + toDescription(registeredValidator) + "'.");
+                    }
+
+                    _log.debug("Adding transformer =>"
+                            + ", Name:" + validator.getName());
+                    _validatorRegistry.addValidator(validator);
+                    _validators.add(validator);
+                }
+            }
+        } catch (DuplicateValidatorException e) {
+            throw e;
+        } catch (RuntimeException e) {
+            // If there was an exception for any reason... remove all Validator instance that have
+            // already been registered with the domain...
+            unregisterValidators();
+            throw e;
+        }
+    }
+
+    /**
+     * Unregister all validators.
+     */
+    public void unregisterValidators() {
+        for (Validator validator : _validators) {
+            _validatorRegistry.removeValidator(validator);
+        }
+    }
+
+    /**
+     * Load the out of the box validators.
+     * <p/>
+     * Scans the classpath for {@link #VALIDATES_XML} runtime configuration resources.
+     */
+    public void loadOOTBValidates() {
+        try {
+            List<URL> resources = Classes.getResources(VALIDATES_XML, getClass());
+
+            for (URL resource : resources) {
+                InputStream configStream = resource.openStream();
+
+                try {
+                    ValidatesModel validatesModel = new ModelPuller<ValidatesModel>().pull(configStream);
+                    registerValidators(validatesModel);
+                } catch (final DuplicateValidatorException e) {
+                    _log.debug(e.getMessage(), e);
+                } finally {
+                    configStream.close();
+                }
+            }
+        } catch (IOException e) {
+            throw new SwitchYardException("Error reading out-of-the-box Validator configurations from classpath (" + VALIDATES_XML + ").", e);
+        }
+    }
+
+    private String toDescription(Validator<?> validator) {
+        return validator.getClass().getName() + "(" + validator.getName() + ")";
+    }
+}

--- a/validate/src/main/java/org/switchyard/validate/ValidatorTypes.java
+++ b/validate/src/main/java/org/switchyard/validate/ValidatorTypes.java
@@ -1,0 +1,49 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+package org.switchyard.validate;
+
+import javax.xml.namespace.QName;
+
+/**
+ * Validator data types.
+ *
+ * @author <a href="mailto:tm.igarashi@gmail.com">Tomohisa Igarashi</a>
+ */
+public class ValidatorTypes {
+
+    private QName _name;
+
+    /**
+     * Public constructor.
+     *
+     * @param name type.
+     */
+    ValidatorTypes(QName name) {
+        this._name = name;
+    }
+
+    /**
+     * Get name.
+     *
+     * @return name.
+     */
+    public QName getName() {
+        return _name;
+    }
+}

--- a/validate/src/main/java/org/switchyard/validate/ValidatorUtil.java
+++ b/validate/src/main/java/org/switchyard/validate/ValidatorUtil.java
@@ -1,0 +1,338 @@
+/* 
+ * JBoss, Home of Professional Open Source 
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved. 
+ * See the copyright.txt in the distribution for a 
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use, 
+ * modify, copy, or redistribute it subject to the terms and conditions 
+ * of the GNU Lesser General Public License, v. 2.1. 
+ * This program is distributed in the hope that it will be useful, but WITHOUT A 
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details. 
+ * You should have received a copy of the GNU Lesser General Public License, 
+ * v.2.1 along with this distribution; if not, write to the Free Software 
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, 
+ * MA  02110-1301, USA.
+ */
+
+package org.switchyard.validate;
+
+import org.switchyard.common.type.Classes;
+import org.switchyard.common.xml.QNameUtil;
+import org.switchyard.config.model.validate.ValidateModel;
+import org.switchyard.exception.SwitchYardException;
+import org.switchyard.metadata.java.JavaService;
+import org.switchyard.validate.config.model.JavaValidateModel;
+
+import javax.xml.namespace.QName;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * Validator Utility methods.
+ *
+ * @author <a href="mailto:tm.igarashi@gmail.com">Tomohisa Igarashi</a>
+ */
+public final class ValidatorUtil {
+
+    private static final QName OBJECT_TYPE = JavaService.toMessageType(Object.class);
+
+    private ValidatorUtil() {}
+
+    /**
+     * Create a new {@link org.switchyard.validate.Validator} instance from the supplied {@link ValidateModel} instance.
+     * @param validateModel The ValidateModel instance.
+     * @return The Validator instance.
+     */
+    public static Validator<?> newValidator(ValidateModel validateModel) {
+        return newValidators(validateModel).iterator().next();
+    }
+
+    /**
+     * Create a Collection of {@link Validator} instances from the supplied {@link ValidateModel} instance.
+     * @param validateModel The ValidateModel instance.
+     * @return The Validator instance.
+     */
+    public static Collection<Validator<?>> newValidators(ValidateModel validateModel) {
+
+        Collection<Validator<?>> validators = null;
+
+        if (validateModel instanceof JavaValidateModel) {
+            String className = ((JavaValidateModel) validateModel).getClazz();
+            try {
+                Class<?> validateClass = Classes.forName(className, ValidatorUtil.class);
+
+                validators = newValidators(validateClass, validateModel.getName());
+            } catch (Exception e) {
+                throw new SwitchYardException("Error constructing Validator instance for class '" + className + "'.", e);
+            }
+        } else {
+            ValidatorFactory factory = newValidatorFactory(validateModel);
+
+            validators = new ArrayList<Validator<?>>();
+            validators.add(factory.newValidator(validateModel));
+        }
+
+        if (validators == null || validators.isEmpty()) {
+            throw new SwitchYardException("Unknown ValidateModel type '" + validateModel.getClass().getName() + "'.");
+        }
+
+        return validators;
+    }
+
+    /**
+     * Create a new {@link org.switchyard.validate.Validator} instance from the supplied
+     * Class and supporting the specified name.
+     * @param clazz The Class representing the Validator.
+     * @param name The name of type.
+     * @return The collection of Validator instances.
+     * @see #isValidator(Class)
+     */
+    public static Validator<?> newValidator(Class<?> clazz, QName name) {
+        return newValidators(clazz, name).iterator().next();
+    }
+
+    /**
+     * Create a Collection of {@link Validator} instances from the supplied
+     * Class and supporting the specified name.
+     * @param clazz The Class representing the Validator.
+     * @param name The name of type.
+     * @return The collection of Validator instances.
+     * @see #isValidator(Class)
+     */
+    public static Collection<Validator<?>> newValidators(Class<?> clazz, QName name) {
+        if (!isValidator(clazz)) {
+            throw new SwitchYardException("Invalid Validator class '" + clazz.getName() + "'.  Must implement the Validator interface, or have methods annotated with the @Validator annotation.");
+        }
+
+        boolean nameIsWild = isWildcardType(name);
+        Collection<Validator<?>> validators = new ArrayList<Validator<?>>();
+        final Object validatorObject;
+
+        try {
+            validatorObject = clazz.newInstance();
+        } catch (Exception e) {
+            throw new SwitchYardException("Error constructing Validator instance for class '" + clazz.getName() + "'.  Class must have a public default constructor.", e);
+        }
+
+        Method[] publicMethods = clazz.getMethods();
+        for (Method publicMethod : publicMethods) {
+            org.switchyard.annotations.Validator validatorAnno = publicMethod.getAnnotation(org.switchyard.annotations.Validator.class);
+            if (validatorAnno != null) {
+                ValidatorMethod validatorMethod = toValidatorMethod(publicMethod, validatorAnno);
+
+                if ((nameIsWild || validatorMethod.getName().equals(name)))  {
+                    validators.add(newValidator(validatorObject, validatorMethod.getMethod(), validatorMethod.getName()));
+                }
+            }
+        }
+
+        if (validatorObject instanceof Validator) {
+            Validator validator = (Validator) validatorObject;
+            QName vldName = validator.getName();
+
+            if (vldName.equals(OBJECT_TYPE)) {
+                // Type info not specified on validator, so assuming it's a generic/multi-type validator...
+                validators.add(validator);
+            } else if ((nameIsWild || vldName.equals(name))) {
+                // Matching (specific) or wildcard type info specified...
+                validators.add(validator);
+            } else if (isAssignableFrom(vldName, name)) {
+                // Compatible Java types...
+                validators.add(validator);
+            }
+
+            if (!nameIsWild) {
+                validator.setName(name);
+            }
+        }
+
+        if (validators.isEmpty()) {
+            throw new SwitchYardException("Error constructing Validator instance for class '" + clazz.getName() + "'.  Class does not support a validation for type '" + name + "'.");
+        }
+
+        return validators;
+    }
+
+    /**
+     * Create a list of all the possible validations that the supplied Class offers.
+     * @param clazz The Class to be analyzed.
+     * @return A Map containing the validation types, with the key/value representing the to/from.
+     */
+    public static List<ValidatorTypes> listValidations(Class<?> clazz) {
+        Object validatorObject;
+        List<ValidatorTypes> validations = new ArrayList<ValidatorTypes>();
+
+        try {
+            validatorObject = clazz.newInstance();
+        } catch (Exception e) {
+            throw new SwitchYardException("Error constructing Validator instance for class '" + clazz.getName() + "'.  Class must have a public default constructor.", e);
+        }
+
+        // If the class itself implements the Validator interface....
+        if (validatorObject instanceof org.switchyard.validate.Validator) {
+            QName name = ((Validator) validatorObject).getName();
+            if (name != null) {
+                validations.add(new ValidatorTypes(name));
+            }
+        }
+
+        // If some of the class methods are annotated with the @Validator annotation...
+        Method[] publicMethods = clazz.getMethods();
+        for (Method publicMethod : publicMethods) {
+            org.switchyard.annotations.Validator validatorAnno = publicMethod.getAnnotation(org.switchyard.annotations.Validator.class);
+            if (validatorAnno != null) {
+                ValidatorMethod validatorMethod = toValidatorMethod(publicMethod, validatorAnno);
+                validations.add(new ValidatorTypes(validatorMethod.getName()));
+            }
+        }
+
+        return validations;
+    }
+
+    /**
+     * Is the supplied Class a SwitchYard Validator class.
+     * <p/>
+     * A SwitchYard Validator class is any class that either implements the {@link org.switchyard.validate.Validator}
+     * interface, or has one or more methods annotated with the {@link org.switchyard.annotations.Validator @Validator} annotation.
+     *
+     * @param clazz The Class instance.
+     * @return True if the class can be used as a SwitchYard Validator, otherwise false.
+     */
+    public static boolean isValidator(Class<?> clazz) {
+        if (clazz.isInterface()) {
+            return false;
+        }
+        if (clazz.isAnnotation()) {
+            return false;
+        }
+        if (Modifier.isAbstract(clazz.getModifiers())) {
+            return false;
+        }
+        try {
+            // Must have a default constructor...
+            clazz.getConstructor();
+        } catch (NoSuchMethodException e) {
+            return false;
+        }
+        if (org.switchyard.validate.Validator.class.isAssignableFrom(clazz)) {
+            return true;
+        }
+
+        Method[] publicMethods = clazz.getMethods();
+        for (Method publicMethod : publicMethods) {
+            if (publicMethod.isAnnotationPresent(org.switchyard.annotations.Validator.class)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static Validator newValidator(final Object validatorObject, final Method publicMethod, QName name) {
+        Validator validator = new BaseValidator(name) {
+            @Override
+            public boolean validate(Object subject) {
+                try {
+                    return Boolean.parseBoolean(publicMethod.invoke(validatorObject, subject).toString());
+                } catch (InvocationTargetException e) {
+                    throw new SwitchYardException("Error executing @Validator method '" + publicMethod.getName() + "' on class '" + publicMethod.getDeclaringClass().getName() + "'.", e.getCause());
+                } catch (Exception e) {
+                    throw new SwitchYardException("Error executing @Validator method '" + publicMethod.getName() + "' on class '" + publicMethod.getDeclaringClass().getName() + "'.", e);
+                }
+            }
+            
+            @Override
+            public Class<?> getType() {
+                return publicMethod.getReturnType();
+            }
+        };
+
+        return validator;
+    }
+
+    private static boolean isAssignableFrom(QName a, QName b) {
+        if (QNameUtil.isJavaMessageType(a) && QNameUtil.isJavaMessageType(b)) {
+            Class<?> aType = QNameUtil.toJavaMessageType(a);
+            Class<?> bType = QNameUtil.toJavaMessageType(b);
+
+            if (aType == null || bType == null) {
+                return false;
+            }
+
+            return aType.isAssignableFrom(bType);
+        }
+
+        return false;
+    }
+
+    private static boolean isWildcardType(QName type) {
+        return type.toString().equals("*");
+    }
+
+    private static ValidatorMethod toValidatorMethod(Method publicMethod, org.switchyard.annotations.Validator validatorAnno) {
+
+        QName name;
+        Class<?> type;
+
+        Class<?>[] params = publicMethod.getParameterTypes();
+        if (params.length != 1) {
+            throw new SwitchYardException("Invalid @Validator method '" + publicMethod.getName() + "' on class '" + publicMethod.getDeclaringClass().getName() + "'.  Must have exactly 1 parameter.");
+        }
+        type = params[0];
+
+        if (!validatorAnno.name().trim().equals("")) {
+            name = QName.valueOf(validatorAnno.name().trim());
+        } else {
+            name = JavaService.toMessageType(type);
+        }
+
+        return new ValidatorMethod(name, publicMethod);
+    }
+
+    private static ValidatorFactory newValidatorFactory(ValidateModel validateModel) {
+        ValidatorFactoryClass validatorFactoryClass = validateModel.getClass().getAnnotation(ValidatorFactoryClass.class);
+
+        if (validatorFactoryClass == null) {
+            throw new SwitchYardException("ValidateModel type '" + validateModel.getClass().getName() + "' is not annotated with an @ValidatorFactoryClass annotation.");
+        }
+
+        Class<?> factoryClass = validatorFactoryClass.value();
+
+        if (!org.switchyard.validate.ValidatorFactory.class.isAssignableFrom(factoryClass)) {
+            throw new SwitchYardException("Invalid ValidatorFactory implementation.  Must implement '" + org.switchyard.validate.ValidatorFactory.class.getName() + "'.");
+        }
+
+        try {
+            return (org.switchyard.validate.ValidatorFactory) factoryClass.newInstance();
+        } catch (Exception e) {
+            throw new SwitchYardException("Failed to create an instance of ValidatorFactory '" + factoryClass.getName() + "'.  Class must have a public default constructor and not be abstract.");
+        }
+    }
+
+    private static class ValidatorMethod extends ValidatorTypes {
+
+        private Method _method;
+
+        /**
+         * Public constructor.
+         *
+         * @param name name of type.
+         * @param publicMethod
+         */
+        ValidatorMethod(QName name, Method publicMethod) {
+            super(name);
+            this._method = publicMethod;
+        }
+
+        private Method getMethod() {
+            return _method;
+        }
+    }
+}

--- a/validate/src/main/java/org/switchyard/validate/config/model/JavaValidateModel.java
+++ b/validate/src/main/java/org/switchyard/validate/config/model/JavaValidateModel.java
@@ -1,0 +1,50 @@
+/* 
+ * JBoss, Home of Professional Open Source 
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved. 
+ * See the copyright.txt in the distribution for a 
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use, 
+ * modify, copy, or redistribute it subject to the terms and conditions 
+ * of the GNU Lesser General Public License, v. 2.1. 
+ * This program is distributed in the hope that it will be useful, but WITHOUT A 
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details. 
+ * You should have received a copy of the GNU Lesser General Public License, 
+ * v.2.1 along with this distribution; if not, write to the Free Software 
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, 
+ * MA  02110-1301, USA.
+ */
+
+package org.switchyard.validate.config.model;
+
+import org.switchyard.config.model.validate.ValidateModel;
+
+/**
+ * A "transform.java" configuration model.
+ *
+ * @author <a href="mailto:tm.igarashi@gmail.com">Tomohisa Igarashi</a>
+ */
+public interface JavaValidateModel extends ValidateModel {
+
+    /** The "java" name. */
+    public static final String JAVA = "java";
+
+    /** The "class" name. */
+    public static final String CLASS = "class";
+
+    /**
+     * Gets the class attribute.
+     * @return the class attribute
+     */
+    public String getClazz();
+
+    /**
+     * Sets the class attribute.
+     * @param clazz the class attribute
+     * @return this JavaValidateModel (useful for chaining)
+     */
+    public JavaValidateModel setClazz(String clazz);
+
+}

--- a/validate/src/main/java/org/switchyard/validate/config/model/ValidateSwitchYardScanner.java
+++ b/validate/src/main/java/org/switchyard/validate/config/model/ValidateSwitchYardScanner.java
@@ -1,0 +1,97 @@
+/* 
+ * JBoss, Home of Professional Open Source 
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved. 
+ * See the copyright.txt in the distribution for a 
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use, 
+ * modify, copy, or redistribute it subject to the terms and conditions 
+ * of the GNU Lesser General Public License, v. 2.1. 
+ * This program is distributed in the hope that it will be useful, but WITHOUT A 
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details. 
+ * You should have received a copy of the GNU Lesser General Public License, 
+ * v.2.1 along with this distribution; if not, write to the Free Software 
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, 
+ * MA  02110-1301, USA.
+ */
+
+package org.switchyard.validate.config.model;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.List;
+
+import org.switchyard.common.type.classpath.AbstractTypeFilter;
+import org.switchyard.common.type.classpath.ClasspathScanner;
+import org.switchyard.config.model.Scannable;
+import org.switchyard.config.model.Scanner; 
+import org.switchyard.config.model.ScannerInput;
+import org.switchyard.config.model.ScannerOutput;
+import org.switchyard.config.model.switchyard.SwitchYardModel;
+import org.switchyard.config.model.switchyard.v1.V1SwitchYardModel;
+import org.switchyard.config.model.validate.ValidatesModel;
+import org.switchyard.config.model.validate.v1.V1ValidatesModel;
+import org.switchyard.validate.ValidatorTypes;
+import org.switchyard.validate.ValidatorUtil;
+import org.switchyard.validate.config.model.v1.V1JavaValidateModel;
+
+/**
+ * Scanner for {@link org.switchyard.validate.Validator} implementations.
+ *
+ * @author <a href="mailto:tm.igarashi@gmail.com">Tomohisa Igarashi</a>
+ */
+public class ValidateSwitchYardScanner implements Scanner<SwitchYardModel> {
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public ScannerOutput<SwitchYardModel> scan(ScannerInput<SwitchYardModel> input) throws IOException {
+        SwitchYardModel switchyardModel = new V1SwitchYardModel();
+        ValidatesModel validatesModel = null;
+
+        List<Class<?>> validatorClasses = scanForValidators(input.getURLs());
+        for (Class<?> validator : validatorClasses) {
+            List<ValidatorTypes> supportedValidators = ValidatorUtil.listValidations(validator);
+
+            for (ValidatorTypes supportedValidate : supportedValidators) {
+                JavaValidateModel validateModel = new V1JavaValidateModel();
+
+                validateModel.setClazz(validator.getName());
+                validateModel.setName(supportedValidate.getName());
+
+                if (validatesModel == null) {
+                    validatesModel = new V1ValidatesModel();
+                    switchyardModel.setValidates(validatesModel);
+                }
+                validatesModel.addValidate(validateModel);
+            }
+        }
+
+        return new ScannerOutput<SwitchYardModel>().setModel(switchyardModel);
+    }
+
+    private List<Class<?>> scanForValidators(List<URL> urls) throws IOException {
+        AbstractTypeFilter filter = new ValidatorInstanceOfFilter();
+        ClasspathScanner scanner = new ClasspathScanner(filter);
+        for (URL url : urls) {
+            scanner.scan(url);
+        }
+
+        return filter.getMatchedTypes();
+    }
+
+    private class ValidatorInstanceOfFilter extends AbstractTypeFilter {
+        @Override
+        public boolean matches(Class<?> clazz) {
+            Scannable scannable = clazz.getAnnotation(Scannable.class);
+            if (scannable != null && !scannable.value()) {
+                // Marked as being non-scannable...
+                return false;
+            }
+            return ValidatorUtil.isValidator(clazz);
+        }
+    }
+}

--- a/validate/src/main/java/org/switchyard/validate/config/model/XmlSchemaType.java
+++ b/validate/src/main/java/org/switchyard/validate/config/model/XmlSchemaType.java
@@ -1,0 +1,40 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+
+package org.switchyard.validate.config.model;
+
+/**
+ * Schema type for XML validation.
+ *
+ * @author <a href="mailto:tm.igarashi@gmail.com">Tomohisa Igarashi</a>
+ */
+public enum XmlSchemaType {
+    /**
+     * DTD.
+     */
+    DTD,
+    /**
+    * W3C XML Schema.
+     */
+    XML_SCHEMA,
+    /**
+     * RELAX NG.
+     */
+    RELAX_NG
+}

--- a/validate/src/main/java/org/switchyard/validate/config/model/XmlValidateModel.java
+++ b/validate/src/main/java/org/switchyard/validate/config/model/XmlValidateModel.java
@@ -1,0 +1,81 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+
+package org.switchyard.validate.config.model;
+
+import org.switchyard.config.model.validate.ValidateModel;
+
+/**
+ * A "validate.xml" configuration model.
+ *
+ * @author <a href="mailto:tm.igarashi@gmail.com">Tomohisa Igarashi</a>
+ */
+public interface XmlValidateModel extends ValidateModel {
+
+    /** The "xml" name. */
+    public static final String XML = "xml";
+    
+    /** schema file. */
+    public static final String SCHEMA_FILE_URI = "schemaFile";
+
+    /** schema language. */
+    public static final String SCHEMA_TYPE = "schemaType";
+    
+    /** whether a warning should be reported as Exception or just log. */
+    public static final String FAIL_ON_WARNING = "failOnWarning";
+            
+    /**
+     * Return whether a warning should be reported as an SwitchYardException.
+     * If failOnWarning attribute is "true", then a warning should be reported
+     * as an SwitchYardException, otherwise just log.
+     * @return true if a warning should be reported as an SwitchYardException, otherwise false
+     */
+    boolean failOnWarning();
+
+    /**
+     * Set whether a warning should be reported as an SwitchYardException.
+     * If failOnWarning attribute is "true", then a warning should be reported
+     * as an SwitchYardException, otherwise just log.
+     * @param failOnWarning true if a warning should be reported as an SwitchYardException, otherwise false
+     * @return model representation
+     */
+    XmlValidateModel setFailOnWarning(boolean failOnWarning);
+    
+    /**
+     * @return schema file
+     */
+    String getSchemaFile();
+
+    /**
+     * @param file schema file
+     * @return model representation
+     */
+    XmlValidateModel setSchemaFile(String file);
+    
+    /**
+     * @return schema type
+     */
+    XmlSchemaType getSchemaType();
+    
+    /**
+     * @param type schema type
+     * @return model representation
+     */
+    XmlValidateModel setSchemaType(XmlSchemaType type);
+}

--- a/validate/src/main/java/org/switchyard/validate/config/model/v1/V1JavaValidateModel.java
+++ b/validate/src/main/java/org/switchyard/validate/config/model/v1/V1JavaValidateModel.java
@@ -1,0 +1,70 @@
+/* 
+ * JBoss, Home of Professional Open Source 
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved. 
+ * See the copyright.txt in the distribution for a 
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use, 
+ * modify, copy, or redistribute it subject to the terms and conditions 
+ * of the GNU Lesser General Public License, v. 2.1. 
+ * This program is distributed in the hope that it will be useful, but WITHOUT A 
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details. 
+ * You should have received a copy of the GNU Lesser General Public License, 
+ * v.2.1 along with this distribution; if not, write to the Free Software 
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, 
+ * MA  02110-1301, USA.
+ */
+
+package org.switchyard.validate.config.model.v1;
+
+import javax.xml.namespace.QName;
+
+import org.switchyard.config.Configuration;
+import org.switchyard.config.model.Descriptor;
+import org.switchyard.config.model.validate.ValidateModel;
+import org.switchyard.config.model.validate.v1.V1BaseValidateModel;
+import org.switchyard.validate.config.model.JavaValidateModel;
+
+/**
+ * A version 1 JavaValidateModel.
+ *
+ * @author <a href="mailto:tm.igarashi@gmail.com">Tomohisa Igarashi</a>
+ */
+public class V1JavaValidateModel extends V1BaseValidateModel implements JavaValidateModel {
+
+    /**
+     * Constructs a new V1JavaValidateModel.
+     */
+    public V1JavaValidateModel() {
+        super(new QName(ValidateModel.DEFAULT_NAMESPACE, ValidateModel.VALIDATE + '.' + JAVA));
+    }
+
+    /**
+     * Constructs a new V1JavaValidateModel with the specified Configuration and Descriptor.
+     * @param config the Configuration
+     * @param desc the Descriptor
+     */
+    public V1JavaValidateModel(Configuration config, Descriptor desc) {
+        super(config, desc);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getClazz() {
+        return getModelAttribute(CLASS);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public JavaValidateModel setClazz(String clazz) {
+        setModelAttribute(CLASS, clazz);
+        return this;
+    }
+
+}

--- a/validate/src/main/java/org/switchyard/validate/config/model/v1/V1ValidateMarshaller.java
+++ b/validate/src/main/java/org/switchyard/validate/config/model/v1/V1ValidateMarshaller.java
@@ -1,0 +1,65 @@
+/* 
+ * JBoss, Home of Professional Open Source 
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved. 
+ * See the copyright.txt in the distribution for a 
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use, 
+ * modify, copy, or redistribute it subject to the terms and conditions 
+ * of the GNU Lesser General Public License, v. 2.1. 
+ * This program is distributed in the hope that it will be useful, but WITHOUT A 
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details. 
+ * You should have received a copy of the GNU Lesser General Public License, 
+ * v.2.1 along with this distribution; if not, write to the Free Software 
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, 
+ * MA  02110-1301, USA.
+ */
+
+package org.switchyard.validate.config.model.v1;
+
+import org.switchyard.config.Configuration;
+import org.switchyard.config.model.BaseMarshaller;
+import org.switchyard.config.model.Descriptor;
+import org.switchyard.config.model.Model;
+import org.switchyard.config.model.validate.ValidateModel;
+import org.switchyard.validate.config.model.JavaValidateModel;
+import org.switchyard.validate.config.model.XmlValidateModel;
+
+/**
+ * Marshalls validate Models.
+ *
+ * @author <a href="mailto:tm.igarashi@gmail.com">Tomohisa Igarashi</a>
+ */
+public class V1ValidateMarshaller extends BaseMarshaller {
+
+    private static final String VALIDATE_JAVA = ValidateModel.VALIDATE + "." + JavaValidateModel.JAVA;
+    private static final String VALIDATE_XML = ValidateModel.VALIDATE + "." + XmlValidateModel.XML;
+
+    /**
+     * Constructs a new V1ValidateMarshaller with the specified Descriptor.
+     * @param desc the Descriptor
+     */
+    public V1ValidateMarshaller(Descriptor desc) {
+        super(desc);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Model read(Configuration config) {
+        String name = config.getName();
+        Descriptor desc = getDescriptor();
+
+        if (name.equals(VALIDATE_JAVA)) {
+            return new V1JavaValidateModel(config, desc);
+        } else if (name.equals(VALIDATE_XML)) {
+            return new V1XmlValidateModel(config, desc);
+        }
+
+        return null;
+    }
+
+}

--- a/validate/src/main/java/org/switchyard/validate/config/model/v1/V1XmlValidateModel.java
+++ b/validate/src/main/java/org/switchyard/validate/config/model/v1/V1XmlValidateModel.java
@@ -1,0 +1,110 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+
+package org.switchyard.validate.config.model.v1;
+
+import org.switchyard.config.Configuration;
+import org.switchyard.config.model.Descriptor;
+import org.switchyard.config.model.validate.ValidateModel;
+import org.switchyard.config.model.validate.v1.V1BaseValidateModel;
+import org.switchyard.validate.ValidatorFactoryClass;
+import org.switchyard.validate.config.model.XmlSchemaType;
+import org.switchyard.validate.config.model.XmlValidateModel;
+import org.switchyard.validate.xml.XmlValidatorFactory;
+import javax.xml.namespace.QName;
+
+/**
+ * A version 1 XmlValidateModel.
+ *
+ * @author <a href="mailto:tm.igarashi@gmail.com">Tomohisa Igarashi</a>
+ */
+@ValidatorFactoryClass(XmlValidatorFactory.class)
+public class V1XmlValidateModel extends V1BaseValidateModel implements XmlValidateModel {
+
+    /**
+     * Constructs a new V1XmlValidateModel.
+     */
+    public V1XmlValidateModel() {
+        super(new QName(ValidateModel.DEFAULT_NAMESPACE, ValidateModel.VALIDATE + '.' + XML));
+    }
+
+    /**
+     * Constructs a new V1XmlValidateModel with the specified Configuration and Descriptor.
+     * @param config the Configuration
+     * @param desc the Descriptor
+     */
+    public V1XmlValidateModel(Configuration config, Descriptor desc) {
+        super(config, desc);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean failOnWarning() {
+        String fow = getModelAttribute(FAIL_ON_WARNING);
+        return Boolean.parseBoolean(fow);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public XmlValidateModel setFailOnWarning(boolean failOnWarning) {
+        setModelAttribute(FAIL_ON_WARNING, Boolean.toString(failOnWarning));
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getSchemaFile() {
+        return getModelAttribute(SCHEMA_FILE_URI);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public XmlValidateModel setSchemaFile(String file) {
+        setModelAttribute(SCHEMA_FILE_URI, file);
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public XmlSchemaType getSchemaType() {
+        String type = getModelAttribute(SCHEMA_TYPE);
+        return type != null ? XmlSchemaType.valueOf(type) : null;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public XmlValidateModel setSchemaType(XmlSchemaType type) {
+        if (type != null) {
+            setModelAttribute(SCHEMA_TYPE, type.toString());
+        }
+        return this;
+    }
+}

--- a/validate/src/main/java/org/switchyard/validate/xml/XmlValidator.java
+++ b/validate/src/main/java/org/switchyard/validate/xml/XmlValidator.java
@@ -1,0 +1,132 @@
+package org.switchyard.validate.xml;
+
+import java.io.IOException;
+import java.io.Reader;
+
+import javax.xml.XMLConstants;
+import javax.xml.namespace.QName;
+import javax.xml.parsers.SAXParserFactory;
+import javax.xml.transform.stream.StreamSource;
+import javax.xml.validation.Schema;
+import javax.xml.validation.SchemaFactory;
+import javax.xml.validation.Validator;
+
+import org.apache.log4j.Logger;
+import org.switchyard.Message;
+import org.switchyard.common.type.Classes;
+import org.switchyard.config.model.Scannable;
+import org.switchyard.exception.SwitchYardException;
+import org.switchyard.validate.BaseValidator;
+import org.switchyard.validate.config.model.XmlSchemaType;
+import org.switchyard.validate.config.model.XmlValidateModel;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+import org.xml.sax.SAXParseException;
+import org.xml.sax.helpers.DefaultHandler;
+
+/**
+ * XML Validator {@link org.switchyard.validate.Validator}.
+ * 
+ * @author <a href="mailto:tm.igarashi@gmail.com">Tomohisa Igarashi</a>
+ */
+@Scannable(false)
+public class XmlValidator extends BaseValidator<Message> {
+
+    private static final Logger LOGGER = Logger.getLogger(XmlValidator.class);
+    private XmlSchemaType _schemaType;
+    private String _schemaTypeUri;
+    private String _schemaFile;
+    private boolean _failOnWarning;
+        
+    /**
+     * constructor.
+     * @param name name
+     * @param model model
+     */
+    public XmlValidator(QName name, XmlValidateModel model) {
+        super(name);
+
+        _schemaType = model.getSchemaType();
+        if (_schemaType == null) {
+            throw new SwitchYardException("Could not instantiate XmlValidator: schemaType must be specified.");
+        }
+        
+        switch(_schemaType) {
+        case DTD:
+            _schemaTypeUri = XMLConstants.XML_DTD_NS_URI;
+            break;
+        case XML_SCHEMA:
+            _schemaTypeUri = XMLConstants.W3C_XML_SCHEMA_NS_URI;
+            break;
+        case RELAX_NG:
+            _schemaTypeUri = XMLConstants.RELAXNG_NS_URI;
+            break;
+        default:
+            throw new SwitchYardException("Could not instantiate XmlValidator: schemaType '" + _schemaType + "' is invalid."
+                    + "It must be the one of " + XmlSchemaType.values() + ".");
+        }
+        
+        _schemaFile = model.getSchemaFile();
+        _failOnWarning = model.failOnWarning();
+        
+    }
+    
+    @Override
+    public boolean validate(Message msg) {
+        if (XMLConstants.W3C_XML_SCHEMA_NS_URI.equals(_schemaTypeUri) || XMLConstants.RELAXNG_NS_URI.equals(_schemaTypeUri)) {
+            // XML Schema or RELAX NG Validation needs schemaFile
+            if (_schemaFile == null) {
+                throw new SwitchYardException("Error during validation: schemaFile must be specified for '" + _schemaType + "'.");
+            }
+
+            SchemaFactory schemaFactory = SchemaFactory.newInstance(_schemaTypeUri);
+            try {
+                Schema schema = schemaFactory.newSchema(new StreamSource(Classes.getResourceAsStream(_schemaFile)));
+                Validator validator = schema.newValidator();
+                validator.setErrorHandler(new XmlValidationErrorHandler(_failOnWarning));
+                validator.validate(new StreamSource(msg.getContent(Reader.class)));
+            } catch (SAXException e) {
+                throw new SwitchYardException("Error during validation with '" + _schemaFile + "' as '" + _schemaType + "'.", e);
+            } catch (IOException ioe) {
+                throw new SwitchYardException("Error during validation with '" + _schemaFile + "' as '" + _schemaType + "'.", ioe);
+            }
+        } else if (XMLConstants.XML_DTD_NS_URI.equals(_schemaTypeUri)) {
+            // DTD Validation
+            SAXParserFactory factory = SAXParserFactory.newInstance();
+            factory.setValidating(true);
+            try {
+                factory.newSAXParser()
+                        .parse(new InputSource(msg.getContent(Reader.class)), new XmlValidationErrorHandler(_failOnWarning));
+            } catch (Exception e) {
+                throw new SwitchYardException("Error during validation with '" + _schemaFile + "' as '" + _schemaType + "'.", e);
+            }
+            
+        } else {
+            throw new SwitchYardException("Unknown XML Schema type '" + _schemaType + "', should be one of '" + XmlSchemaType.values() + "'.");
+        }
+        
+        return true;
+    }
+
+    private class XmlValidationErrorHandler extends DefaultHandler {
+        private boolean _failOnWarning;
+
+        public XmlValidationErrorHandler(boolean failOnWarning) {
+            _failOnWarning = failOnWarning;
+        }
+        
+        @Override
+        public void error(SAXParseException e) throws SAXException {
+            throw e;
+        }
+        
+        @Override
+        public void warning(SAXParseException e) throws SAXException {
+            if (_failOnWarning) {
+                throw e;
+            } else {
+                LOGGER.warn("Warning during validation with '" + _schemaFile + "' as '" + _schemaType + "'", e);
+            }
+        }
+    }
+}

--- a/validate/src/main/java/org/switchyard/validate/xml/XmlValidatorFactory.java
+++ b/validate/src/main/java/org/switchyard/validate/xml/XmlValidatorFactory.java
@@ -1,0 +1,42 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+package org.switchyard.validate.xml;
+
+import org.apache.log4j.Logger;
+import org.switchyard.validate.Validator;
+import org.switchyard.validate.ValidatorFactory;
+import org.switchyard.validate.config.model.XmlValidateModel;
+
+/**
+ * @author <a href="mailto:tm.igarashi@gmail.com">Tomohisa Igarashi</a>
+ */
+public final class XmlValidatorFactory implements ValidatorFactory<XmlValidateModel>{
+
+    private static final Logger LOGGER = Logger.getLogger(XmlValidatorFactory.class);
+    
+    /**
+     * Create a {@link Validator} instance from the supplied {@link XmlValidateModel}.
+     * @param model the XML Validator model. 
+     * @return the Transformer instance.
+     */
+    public Validator newValidator(XmlValidateModel model) {
+        return new XmlValidator(model.getName(), model);
+    }
+    
+}

--- a/validate/src/main/resources/org/switchyard/config/model/descriptor.properties
+++ b/validate/src/main/resources/org/switchyard/config/model/descriptor.properties
@@ -1,0 +1,21 @@
+# JBoss, Home of Professional Open Source
+# Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+# as indicated by the @authors tag. All rights reserved.
+# See the copyright.txt in the distribution for a
+# full listing of individual contributors.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions
+# of the GNU Lesser General Public License, v. 2.1.
+# This program is distributed in the hope that it will be useful, but WITHOUT A
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+# PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+# You should have received a copy of the GNU Lesser General Public License,
+# v.2.1 along with this distribution; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+# MA  02110-1301, USA.
+
+vldt1.namespace=urn:switchyard-config:validate:1.0
+vldt1.schema=validate-v1.xsd
+vldt1.location=/org/switchyard/validate/config/model/v1/
+vldt1.marshaller=org.switchyard.validate.config.model.v1.V1ValidateMarshaller

--- a/validate/src/main/resources/org/switchyard/validate/config/model/v1/validate-v1.xsd
+++ b/validate/src/main/resources/org/switchyard/validate/config/model/v1/validate-v1.xsd
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+JBoss, Home of Professional Open Source
+Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+as indicated by the @authors tag. All rights reserved.
+See the copyright.txt in the distribution for a
+full listing of individual contributors.
+
+This copyrighted material is made available to anyone wishing to use,
+modify, copy, or redistribute it subject to the terms and conditions
+of the GNU Lesser General Public License, v. 2.1.
+This program is distributed in the hope that it will be useful, but WITHOUT A
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+You should have received a copy of the GNU Lesser General Public License,
+v.2.1 along with this distribution; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+MA  02110-1301, USA.
+-->
+<schema xmlns="http://www.w3.org/2001/XMLSchema"
+        targetNamespace="urn:switchyard-config:validate:1.0"
+        xmlns:swyd="urn:switchyard-config:switchyard:1.0"
+        xmlns:vldt="urn:switchyard-config:validate:1.0"
+        elementFormDefault="qualified">
+
+    <import namespace="urn:switchyard-config:switchyard:1.0"/>
+
+    <element name="validate.xml" type="vldt:XmlValidateType" substitutionGroup="swyd:validate" />
+    <complexType name="XmlValidateType">
+        <annotation>
+            <documentation xml:lang="en">
+                XML Validator Configuration.
+            </documentation>
+        </annotation>
+        <complexContent>
+            <extension base="swyd:ValidateType">
+                <attribute name="schemaType" type="vldt:xmlSchemaType" use="required">
+                    <annotation>
+                        <documentation xml:lang="en">
+                            XML schema type.
+                        </documentation>
+                    </annotation>
+                </attribute>
+                <attribute name="schemaFile" type="string" use="required">
+                    <annotation>
+                        <documentation xml:lang="en">
+                            Path to a file containing the XSL schema definition.
+                        </documentation>
+                    </annotation>
+                </attribute>
+                <attribute name="failOnWarning" type="string" use="optional">
+                    <annotation>
+                        <documentation xml:lang="en">
+                            whether a warning should be reported as an SwitchYardException or just log. default is false
+                        </documentation>
+                    </annotation>
+                </attribute>
+            </extension>
+        </complexContent>
+    </complexType>
+    
+    <element name="validate.java" type="vldt:JavaValidateType" substitutionGroup="swyd:validate" />
+    <complexType name="JavaValidateType">
+        <annotation>
+            <documentation xml:lang="en">
+                Generic/Custom Java Validator Configuration.
+            </documentation>
+        </annotation>
+        <complexContent>
+            <extension base="swyd:ValidateType">
+                <attribute name="class" type="string" use="required">
+                    <annotation>
+                        <documentation xml:lang="en">
+                            The name of the Java Validator implementation class.
+                        </documentation>
+                    </annotation>
+                </attribute>
+            </extension>
+        </complexContent>
+    </complexType>
+
+    <simpleType name="xmlSchemaType">
+        <restriction base="string">
+            <enumeration value="DTD">
+                <annotation>
+                    <documentation xml:lang="en">
+                        DTD.
+                    </documentation>
+                </annotation>
+            </enumeration>
+            <enumeration value="XML_SCHEMA">
+                <annotation>
+                    <documentation xml:lang="en">
+                        W3C XML Schema.
+                    </documentation>
+                </annotation>
+            </enumeration>
+            <enumeration value="RELAX_NG">
+                <annotation>
+                    <documentation xml:lang="en">
+                        RELAX NG.
+                    </documentation>
+                </annotation>
+            </enumeration>
+        </restriction>
+    </simpleType>
+
+</schema>

--- a/validate/src/test/java/org/switchyard/validate/AbstractValidatorTestCase.java
+++ b/validate/src/test/java/org/switchyard/validate/AbstractValidatorTestCase.java
@@ -1,0 +1,61 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+
+package org.switchyard.validate;
+
+import org.junit.Assert;
+import org.switchyard.common.type.Classes;
+import org.switchyard.config.model.ModelPuller;
+import org.switchyard.config.model.switchyard.SwitchYardModel;
+import org.switchyard.config.model.validate.ValidateModel;
+import org.switchyard.config.model.validate.ValidatesModel;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * @author <a href="mailto:tm.igarashi@gmail.com">Tomohisa Igarashi</a>
+ */
+public abstract class AbstractValidatorTestCase {
+
+    protected Validator getValidator(String config) throws IOException {
+        InputStream swConfigStream = Classes.getResourceAsStream(config, getClass());
+
+        if (swConfigStream == null) {
+            Assert.fail("null config stream.");
+        }
+
+        SwitchYardModel switchyardConfig;
+        try {
+            switchyardConfig = new ModelPuller<SwitchYardModel>().pull(swConfigStream);
+        } finally {
+            swConfigStream.close();
+        }
+
+        ValidatesModel validates = switchyardConfig.getValidates();
+
+        ValidateModel validateModel = validates.getValidates().get(0);
+
+        if (validateModel == null) {
+            Assert.fail("No validate config.");
+        }
+
+        return ValidatorUtil.newValidator(validateModel);
+    }
+}

--- a/validate/src/test/java/org/switchyard/validate/MessageValidator.java
+++ b/validate/src/test/java/org/switchyard/validate/MessageValidator.java
@@ -1,0 +1,41 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+
+package org.switchyard.validate;
+
+import org.switchyard.Message;
+import org.switchyard.transform.BaseTransformer;
+
+/**
+ * @author <a href="mailto:tm.igarashi@gmail.com">Tomohisa Igarashi</a>
+ */
+public class MessageValidator<T> extends BaseValidator<Message> {
+
+    private Message _message;
+
+    @Override
+    public boolean validate(Message message) {
+        this._message = message;
+        return message != null;
+    }
+
+    public Message getMessage() {
+        return _message;
+    }
+}

--- a/validate/src/test/java/org/switchyard/validate/MessageValidatorTest.java
+++ b/validate/src/test/java/org/switchyard/validate/MessageValidatorTest.java
@@ -1,0 +1,46 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+
+package org.switchyard.validate;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.switchyard.internal.DefaultMessage;
+import org.switchyard.internal.transform.BaseTransformerRegistry;
+import org.switchyard.transform.TransformSequence;
+
+import javax.xml.namespace.QName;
+import java.io.IOException;
+
+/**
+ * @author <a href="mailto:tm.igarashi@gmail.com">Tomohisa Igarashi</a>
+ */
+public class MessageValidatorTest {
+
+    @Test
+    public void test() throws IOException {
+        final QName A = new QName("a");
+
+        DefaultMessage message = new DefaultMessage().setContent(A);
+        MessageValidator validator = new MessageValidator();
+
+        Assert.assertTrue(validator.validate(message));
+        Assert.assertEquals(message, validator.getMessage());
+    }
+}

--- a/validate/src/test/java/org/switchyard/validate/config/model/ValidateModelTests.java
+++ b/validate/src/test/java/org/switchyard/validate/config/model/ValidateModelTests.java
@@ -1,0 +1,132 @@
+/* 
+ * JBoss, Home of Professional Open Source 
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved. 
+ * See the copyright.txt in the distribution for a 
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use, 
+ * modify, copy, or redistribute it subject to the terms and conditions 
+ * of the GNU Lesser General Public License, v. 2.1. 
+ * This program is distributed in the hope that it will be useful, but WITHOUT A 
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details. 
+ * You should have received a copy of the GNU Lesser General Public License, 
+ * v.2.1 along with this distribution; if not, write to the Free Software 
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, 
+ * MA  02110-1301, USA.
+ */
+
+package org.switchyard.validate.config.model;
+
+import java.io.StringReader;
+
+import javax.xml.namespace.QName;
+
+import junit.framework.Assert;
+
+import org.custommonkey.xmlunit.Diff;
+import org.custommonkey.xmlunit.XMLUnit;
+import org.junit.Before;
+import org.junit.Test;
+import org.switchyard.common.io.pull.StringPuller;
+import org.switchyard.common.xml.XMLHelper;
+import org.switchyard.config.model.Model;
+import org.switchyard.config.model.ModelPuller;
+import org.switchyard.config.model.switchyard.SwitchYardModel;
+import org.switchyard.config.model.switchyard.v1.V1SwitchYardModel;
+import org.switchyard.config.model.validate.ValidateModel;
+import org.switchyard.config.model.validate.ValidatesModel;
+import org.switchyard.config.model.validate.v1.V1ValidatesModel;
+import org.switchyard.validate.config.model.v1.V1JavaValidateModel;
+import org.switchyard.validate.config.model.v1.V1XmlValidateModel;
+
+/**
+ * ValidateModelTests.
+ *
+ * @author <a href="mailto:tm.igarashi@gmail.com">Tomohisa Igarashi</a>
+ */
+public class ValidateModelTests {
+
+    private static final String XML = "/org/switchyard/validate/config/model/ValidateModelTests.xml";
+
+    private ModelPuller<SwitchYardModel> _puller;
+
+    @Before
+    public void before() throws Exception {
+        _puller = new ModelPuller<SwitchYardModel>();
+    }
+
+    @Test
+    public void testCreateEmptyModel() throws Exception {
+        String namespace = ValidateModel.DEFAULT_NAMESPACE;
+        String name = ValidateModel.VALIDATE + '.' + JavaValidateModel.JAVA;
+        Model model = new ModelPuller<Model>().pull(XMLHelper.createQName(namespace, name));
+        Assert.assertTrue(model instanceof JavaValidateModel);
+        Assert.assertEquals(name, model.getModelConfiguration().getName());
+        Assert.assertEquals(new QName(namespace, name), model.getModelConfiguration().getQName());
+    }
+
+    @Test
+    public void testCreate() throws Exception {
+        SwitchYardModel switchyard = new V1SwitchYardModel();
+        ValidatesModel validates = new V1ValidatesModel();
+        JavaValidateModel javaValidate = new V1JavaValidateModel();
+        javaValidate.setName(new QName("msgA"));
+        javaValidate.setClazz("org.examples.validate.AValidate");
+        validates.addValidate(javaValidate);
+        XmlValidateModel xmlValidate = new V1XmlValidateModel();
+        xmlValidate.setName(new QName("msgB"));
+        xmlValidate.setSchemaType(XmlSchemaType.XML_SCHEMA);
+        xmlValidate.setSchemaFile("/validates/xxx.xml");
+        xmlValidate.setFailOnWarning(true);
+        validates.addValidate(xmlValidate);
+        switchyard.setValidates(validates);
+        String new_xml = switchyard.toString();
+        String old_xml = new ModelPuller<SwitchYardModel>().pull(XML, getClass()).toString();
+        XMLUnit.setIgnoreWhitespace(true);
+        Diff diff = XMLUnit.compareXML(old_xml, new_xml);
+        Assert.assertTrue(diff.toString(), diff.identical());
+    }
+
+    @Test
+    public void testRead() throws Exception {
+        SwitchYardModel switchyard = _puller.pull(XML, getClass());
+        ValidatesModel validates = switchyard.getValidates();
+        JavaValidateModel java_validate = (JavaValidateModel)validates.getValidates().get(0);
+        Assert.assertEquals("msgA", java_validate.getName().getLocalPart());
+        Assert.assertEquals("org.examples.validate.AValidate", java_validate.getClazz());
+        XmlValidateModel xml_validate = (XmlValidateModel)validates.getValidates().get(1);
+        Assert.assertEquals("msgB", xml_validate.getName().getLocalPart());
+        Assert.assertEquals("/validates/xxx.xml", xml_validate.getSchemaFile());
+
+    }
+
+    @Test
+    public void testWrite() throws Exception {
+        String old_xml = new StringPuller().pull(XML, getClass());
+        SwitchYardModel switchyard = _puller.pull(new StringReader(old_xml));
+        String new_xml = switchyard.toString();
+        XMLUnit.setIgnoreWhitespace(true);
+        Diff diff = XMLUnit.compareXML(old_xml, new_xml);
+        Assert.assertTrue(diff.toString(), diff.identical());
+    }
+
+    @Test
+    public void testParenthood() throws Exception {
+        SwitchYardModel switchyard_1 = _puller.pull(XML, getClass());
+        ValidatesModel validates_1 = switchyard_1.getValidates();
+        ValidateModel validate = validates_1.getValidates().get(0);
+        ValidatesModel validates_2 = validate.getValidates();
+        SwitchYardModel switchyard_2 = validates_2.getSwitchYard();
+        Assert.assertEquals(validates_1, validates_2);
+        Assert.assertEquals(switchyard_1, switchyard_2);
+    }
+
+    @Test
+    public void testValidation() throws Exception {
+        SwitchYardModel switchyard = _puller.pull(XML, getClass());
+        switchyard.assertModelValid();
+    }
+
+}

--- a/validate/src/test/java/org/switchyard/validate/config/model/ValidateSwitchYardScannerTest.java
+++ b/validate/src/test/java/org/switchyard/validate/config/model/ValidateSwitchYardScannerTest.java
@@ -1,0 +1,66 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+
+package org.switchyard.validate.config.model;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.switchyard.config.model.ScannerInput;
+import org.switchyard.config.model.switchyard.SwitchYardModel;
+import org.switchyard.config.model.validate.ValidateModel;
+import org.switchyard.validate.config.model.validators.AValidator;
+import org.switchyard.validate.config.model.validators.BValidator;
+
+/**
+ * @author <a href="mailto:tm.igarashi@gmail.com">Tomohisa Igarashi</a>
+ */
+public class ValidateSwitchYardScannerTest {
+
+    @Test
+    public void test() throws IOException {
+        ValidateSwitchYardScanner scanner = new ValidateSwitchYardScanner();
+        List<URL> urls = new ArrayList<URL>();
+
+        // If running this test inside your IDE... you need to set the cwd to be the
+        // root of the validate module !!
+        urls.add(new File("./target/test-classes").toURI().toURL());
+
+        ScannerInput<SwitchYardModel> input = new ScannerInput<SwitchYardModel>().setURLs(urls);
+        SwitchYardModel switchyard = scanner.scan(input).getModel();
+        List<ValidateModel> models = switchyard.getValidates().getValidates();
+
+        Assert.assertEquals(8, models.size());
+        assertModelInstanceOK((JavaValidateModel) models.get(0));
+        assertModelInstanceOK((JavaValidateModel) models.get(1));
+    }
+
+    private void assertModelInstanceOK(JavaValidateModel model) {
+        if (model.getName().toString().equals("{urn:switchyard-validate:test-validators:1.0}a")) {
+            Assert.assertEquals(AValidator.class.getName(), model.getClazz());
+        } else if (model.getName().toString().equals("{urn:switchyard-validate:test-validators:1.0}b")) {
+            Assert.assertEquals(BValidator.class.getName(), model.getClazz());
+        }
+    }
+}

--- a/validate/src/test/java/org/switchyard/validate/config/model/ValidatorUtilTest.java
+++ b/validate/src/test/java/org/switchyard/validate/config/model/ValidatorUtilTest.java
@@ -1,0 +1,137 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+
+package org.switchyard.validate.config.model;
+
+import junit.framework.Assert;
+import org.junit.Test;
+import org.switchyard.annotations.Validator;
+import org.switchyard.metadata.java.JavaService;
+import org.switchyard.validate.BaseValidator;
+import org.switchyard.validate.ValidatorTypes;
+import org.switchyard.validate.ValidatorUtil;
+
+import javax.xml.namespace.QName;
+import java.util.List;
+
+/**
+ * @author <a href="mailto:tm.igarashi@gmail.com">Tomohisa Igarashi</a>
+ */
+public class ValidatorUtilTest {
+
+    @Test
+    public void test_listValidations() {
+        List<ValidatorTypes> validateTypes = ValidatorUtil.listValidations(TestValidator.class);
+
+        Assert.assertEquals(4, validateTypes.size());
+        Assert.assertEquals(JavaService.toMessageType(A.class), validateTypes.get(0).getName());
+        Assert.assertEquals(JavaService.toMessageType(B.class), validateTypes.get(1).getName());
+        Assert.assertEquals(QName.valueOf("X"), validateTypes.get(2).getName());
+        Assert.assertEquals(QName.valueOf("Z"), validateTypes.get(3).getName());
+    }
+
+    @Test
+    public void test_validate_interface_impl() {
+        org.switchyard.validate.Validator validator = ValidatorUtil.newValidator(TestValidator.class, JavaService.toMessageType(A.class));
+
+        Assert.assertTrue(validator instanceof TestValidator);
+        Assert.assertTrue(validator.validate(new A()));
+    }
+
+    @Test
+    public void test_validate_anno_no_types_defined() {
+        org.switchyard.validate.Validator validator = ValidatorUtil.newValidator(TestValidator.class, JavaService.toMessageType(B.class));
+
+        Assert.assertTrue(!(validator instanceof TestValidator));
+        Assert.assertTrue(validator.validate(new B()));
+    }
+
+    @Test
+    public void test_validate_unknown() {
+        try {
+            ValidatorUtil.newValidator(TestValidator.class, QName.valueOf("AAA"));
+            Assert.fail("Expected Exception");
+        } catch(RuntimeException e) {
+            Assert.assertEquals("Error constructing Validator instance for class 'org.switchyard.validate.config.model.ValidatorUtilTest$TestValidator'.  " +
+                    "Class does not support a validation for type 'AAA'.",
+                    e.getMessage());
+        }
+    }
+
+    @Test
+    public void test_validate_anno_types_defined() {
+        org.switchyard.validate.Validator validator = ValidatorUtil.newValidator(TestValidator.class, QName.valueOf("X"));
+
+        Assert.assertTrue(!(validator instanceof TestValidator));
+        Assert.assertTrue(validator.validate("X"));
+    }
+
+
+    @Test
+    public void test_listNSdValidations() {
+        List<ValidatorTypes> validateTypes = ValidatorUtil.listValidations(NSdTestValidator.class);
+
+        Assert.assertEquals(1, validateTypes.size());
+        Assert.assertEquals(new QName("http://b", "B"), validateTypes.get(0).getName());
+    }
+
+    public static class TestValidator extends BaseValidator {
+
+        public TestValidator() {
+            super(JavaService.toMessageType(A.class));
+        }
+
+        @Override
+        public boolean validate(Object obj) {
+            return obj instanceof Object;
+        }
+
+        @Validator
+        public boolean validateB(B b) {
+            return b instanceof B;
+        }
+
+        @Validator(name = "X")
+        public boolean validateX(String x) {
+            return x.equals("X");
+        }
+
+        @Validator(name = "Z")
+        public boolean validateZ(B z) {
+            return z instanceof B;
+        }
+
+    }
+
+    public static class NSdTestValidator {
+
+        @Validator(name = "{http://b}B")
+        public boolean validateB(B b) {
+            return b instanceof B;
+        }
+    }
+
+    public static class A {
+
+    }
+
+    public static class B {
+
+    }
+}

--- a/validate/src/test/java/org/switchyard/validate/config/model/validators/AValidator.java
+++ b/validate/src/test/java/org/switchyard/validate/config/model/validators/AValidator.java
@@ -1,0 +1,42 @@
+/* 
+ * JBoss, Home of Professional Open Source 
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved. 
+ * See the copyright.txt in the distribution for a 
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use, 
+ * modify, copy, or redistribute it subject to the terms and conditions 
+ * of the GNU Lesser General Public License, v. 2.1. 
+ * This program is distributed in the hope that it will be useful, but WITHOUT A 
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details. 
+ * You should have received a copy of the GNU Lesser General Public License, 
+ * v.2.1 along with this distribution; if not, write to the Free Software 
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, 
+ * MA  02110-1301, USA.
+ */
+
+package org.switchyard.validate.config.model.validators;
+
+import javax.xml.namespace.QName;
+
+import org.switchyard.validate.BaseValidator;
+
+/**
+ * @author <a href="mailto:tm.igarashi@gmail.com">Tomohisa Igarashi</a>
+ */
+@SuppressWarnings("rawtypes")
+public class AValidator extends BaseValidator {
+
+    @Override
+    public boolean validate(Object obj) {
+        return obj instanceof Object;
+    }
+
+    @Override
+    public QName getName() {
+        return new QName("urn:switchyard-validate:test-validators:1.0", "a");
+    }
+
+}

--- a/validate/src/test/java/org/switchyard/validate/config/model/validators/BValidator.java
+++ b/validate/src/test/java/org/switchyard/validate/config/model/validators/BValidator.java
@@ -1,0 +1,42 @@
+/* 
+ * JBoss, Home of Professional Open Source 
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved. 
+ * See the copyright.txt in the distribution for a 
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use, 
+ * modify, copy, or redistribute it subject to the terms and conditions 
+ * of the GNU Lesser General Public License, v. 2.1. 
+ * This program is distributed in the hope that it will be useful, but WITHOUT A 
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details. 
+ * You should have received a copy of the GNU Lesser General Public License, 
+ * v.2.1 along with this distribution; if not, write to the Free Software 
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, 
+ * MA  02110-1301, USA.
+ */
+
+package org.switchyard.validate.config.model.validators;
+
+import javax.xml.namespace.QName;
+
+import org.switchyard.validate.BaseValidator;
+
+/**
+ * @author <a href="mailto:tm.igarashi@gmail.com">Tomohisa Igarashi</a>
+ */
+@SuppressWarnings("rawtypes")
+public class BValidator extends BaseValidator {
+
+    @Override
+    public boolean validate(Object obj) {
+        return obj instanceof Object;
+    }
+
+    @Override
+    public QName getName() {
+        return new QName("urn:switchyard-validate:test-validators:1.0", "b");
+    }
+
+}

--- a/validate/src/test/java/org/switchyard/validate/config/model/validators/XAbstractValidator.java
+++ b/validate/src/test/java/org/switchyard/validate/config/model/validators/XAbstractValidator.java
@@ -1,0 +1,30 @@
+/* 
+ * JBoss, Home of Professional Open Source 
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved. 
+ * See the copyright.txt in the distribution for a 
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use, 
+ * modify, copy, or redistribute it subject to the terms and conditions 
+ * of the GNU Lesser General Public License, v. 2.1. 
+ * This program is distributed in the hope that it will be useful, but WITHOUT A 
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details. 
+ * You should have received a copy of the GNU Lesser General Public License, 
+ * v.2.1 along with this distribution; if not, write to the Free Software 
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, 
+ * MA  02110-1301, USA.
+ */
+
+package org.switchyard.validate.config.model.validators;
+
+import org.switchyard.validate.Validator;
+
+/**
+ * @author <a href="mailto:tm.igarashi@gmail.com">Tomohisa Igarashi</a>
+ */
+@SuppressWarnings("rawtypes")
+public abstract class XAbstractValidator implements Validator{
+    // Should be skipped by the scanner because it is abstract
+}

--- a/validate/src/test/java/org/switchyard/validate/config/model/validators/XValidatorInterface.java
+++ b/validate/src/test/java/org/switchyard/validate/config/model/validators/XValidatorInterface.java
@@ -1,0 +1,30 @@
+/* 
+ * JBoss, Home of Professional Open Source 
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved. 
+ * See the copyright.txt in the distribution for a 
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use, 
+ * modify, copy, or redistribute it subject to the terms and conditions 
+ * of the GNU Lesser General Public License, v. 2.1. 
+ * This program is distributed in the hope that it will be useful, but WITHOUT A 
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details. 
+ * You should have received a copy of the GNU Lesser General Public License, 
+ * v.2.1 along with this distribution; if not, write to the Free Software 
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, 
+ * MA  02110-1301, USA.
+ */
+
+package org.switchyard.validate.config.model.validators;
+
+import org.switchyard.validate.Validator;
+
+/**
+ * @author <a href="mailto:tm.igarashi@gmail.com">Tomohisa Igarashi</a>
+ */
+@SuppressWarnings("rawtypes")
+public interface XValidatorInterface extends Validator{
+    // Should be skipped by the scanner because it's an interface
+}

--- a/validate/src/test/java/org/switchyard/validate/internal/xml/XmlValidatorTest.java
+++ b/validate/src/test/java/org/switchyard/validate/internal/xml/XmlValidatorTest.java
@@ -1,0 +1,93 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+
+package org.switchyard.validate.internal.xml;
+
+import java.io.IOException;
+import java.io.StringReader;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.switchyard.internal.DefaultMessage;
+import org.switchyard.validate.Validator;
+import org.switchyard.validate.AbstractValidatorTestCase;
+import org.switchyard.validate.xml.XmlValidator;
+import org.xml.sax.SAXException;
+
+/**
+ * @author <a href="mailto:tm.igarashi@gmail.com">Tomohisa Igarashi</a>
+ */
+public class XmlValidatorTest extends AbstractValidatorTestCase {
+
+    @Test
+    public void test_no_schematype() throws IOException {
+        try {
+            getValidator("sw-config-no-schematype.xml");
+        } catch(RuntimeException e) {
+            Assert.assertEquals("Could not instantiate XmlValidator: schemaType must be specified.", e.getMessage());
+        }
+    }
+
+    @Test
+    public void test_no_schemafile() throws IOException, SAXException {
+        Validator validator = getValidator("sw-config-no-schemafile.xml");
+        try {
+            validator.validate(new DefaultMessage().setContent(new StringReader("<order type='A' />")));
+        } catch(RuntimeException e) {
+            Assert.assertEquals("Error during validation: schemaFile must be specified for 'XML_SCHEMA'.", e.getMessage());
+        }
+    }
+
+    @Test
+    public void test_invalid_schemafile() throws IOException, SAXException {
+        Validator validator = getValidator("sw-config-invalid-schemafile.xml");
+        try {
+            validator.validate(new DefaultMessage().setContent(new StringReader("<order type='A' />")));
+        } catch(RuntimeException e) {
+            Assert.assertEquals("Error during validation with '/org/switchyard/validate/internal/xml/person-invalid.xsd' as 'XML_SCHEMA'.", e.getMessage());
+        }
+    }
+
+    @Test
+    public void test_valid_xml() throws IOException, SAXException {
+        Validator validator = getValidator("sw-config-xmlv-01.xml");
+        Assert.assertTrue(validator.validate(new DefaultMessage().setContent(new StringReader("<person name='foo' age='50' />"))));
+    }
+
+    @Test
+    public void test_invalid_xml() throws IOException, SAXException {
+        Validator validator = getValidator("sw-config-xmlv-01.xml");
+        try {
+            validator.validate(new DefaultMessage().setContent(new StringReader("<person name='foo'/>")));
+        } catch (RuntimeException e) {
+            Assert.assertEquals("Error during validation with '/org/switchyard/validate/internal/xml/person.xsd' as 'XML_SCHEMA'.", e.getMessage());
+        }
+    }
+
+
+    protected Validator getValidator(String config) throws IOException {
+        Validator validator = super.getValidator(config);
+
+        if(!(validator instanceof XmlValidator)) {
+            Assert.fail("Not an instance of XmlValidator.");
+        }
+
+        return validator;
+    }
+}

--- a/validate/src/test/resources/org/switchyard/validate/MessageValidatorTest.xml
+++ b/validate/src/test/resources/org/switchyard/validate/MessageValidatorTest.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ JBoss, Home of Professional Open Source
+  ~ Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+  ~ as indicated by the @authors tag. All rights reserved.
+  ~ See the copyright.txt in the distribution for a
+  ~ full listing of individual contributors.
+  ~  *
+  ~ This copyrighted material is made available to anyone wishing to use,
+  ~ modify, copy, or redistribute it subject to the terms and conditions
+  ~ of the GNU Lesser General Public License, v. 2.1.
+  ~ This program is distributed in the hope that it will be useful, but WITHOUT A
+  ~ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+  ~ PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+  ~ You should have received a copy of the GNU Lesser General Public License,
+  ~ v.2.1 along with this distribution; if not, write to the Free Software
+  ~ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+  ~ MA  02110-1301, USA.
+  -->
+<switchyard xmlns="urn:switchyard-config:switchyard:1.0">
+    <transforms>
+        <transform.java xmlns="urn:switchyard-config:transform:1.0" from="msgA" to="msgB" class="org.switchyard.transform.Message2MessageTransformer" />
+    </transforms>
+</switchyard>

--- a/validate/src/test/resources/org/switchyard/validate/config/model/ValidateModelTests.xml
+++ b/validate/src/test/resources/org/switchyard/validate/config/model/ValidateModelTests.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+JBoss, Home of Professional Open Source
+Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+as indicated by the @authors tag. All rights reserved.
+See the copyright.txt in the distribution for a
+full listing of individual contributors.
+
+This copyrighted material is made available to anyone wishing to use,
+modify, copy, or redistribute it subject to the terms and conditions
+of the GNU Lesser General Public License, v. 2.1.
+This program is distributed in the hope that it will be useful, but WITHOUT A
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+You should have received a copy of the GNU Lesser General Public License,
+v.2.1 along with this distribution; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+MA  02110-1301, USA.
+-->
+<switchyard xmlns="urn:switchyard-config:switchyard:1.0">
+    <validates>
+        <validate.java xmlns="urn:switchyard-config:validate:1.0" name="msgA" class="org.examples.validate.AValidate"/>
+        <validate.xml xmlns="urn:switchyard-config:validate:1.0" schemaType="XML_SCHEMA" name="msgB" schemaFile="/validates/xxx.xml" failOnWarning="true"/>
+    </validates>
+</switchyard>

--- a/validate/src/test/resources/org/switchyard/validate/internal/xml/person-invalid.xsd
+++ b/validate/src/test/resources/org/switchyard/validate/internal/xml/person-invalid.xsd
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+JBoss, Home of Professional Open Source
+Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+as indicated by the @authors tag. All rights reserved.
+See the copyright.txt in the distribution for a
+full listing of individual contributors.
+
+This copyrighted material is made available to anyone wishing to use,
+modify, copy, or redistribute it subject to the terms and conditions
+of the GNU Lesser General Public License, v. 2.1.
+This program is distributed in the hope that it will be useful, but WITHOUT A
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+You should have received a copy of the GNU Lesser General Public License,
+v.2.1 along with this distribution; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+MA  02110-1301, USA.
+-->
+<schema xmlns="http://www.w3.org/2001/XMLSchema">
+    <element name="person">
+        <complexType>
+            <attribute name="name" type="string" use="required"/>
+            <attribute name="age" type="string" use="required"/>
+    </element>
+</schema>

--- a/validate/src/test/resources/org/switchyard/validate/internal/xml/person.xsd
+++ b/validate/src/test/resources/org/switchyard/validate/internal/xml/person.xsd
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+JBoss, Home of Professional Open Source
+Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+as indicated by the @authors tag. All rights reserved.
+See the copyright.txt in the distribution for a
+full listing of individual contributors.
+
+This copyrighted material is made available to anyone wishing to use,
+modify, copy, or redistribute it subject to the terms and conditions
+of the GNU Lesser General Public License, v. 2.1.
+This program is distributed in the hope that it will be useful, but WITHOUT A
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+You should have received a copy of the GNU Lesser General Public License,
+v.2.1 along with this distribution; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+MA  02110-1301, USA.
+-->
+<schema xmlns="http://www.w3.org/2001/XMLSchema">
+    <element name="person">
+        <complexType>
+            <attribute name="name" type="string" use="required"/>
+            <attribute name="age" type="string" use="required"/>
+        </complexType>
+    </element>
+</schema>

--- a/validate/src/test/resources/org/switchyard/validate/internal/xml/sw-config-invalid-schemafile.xml
+++ b/validate/src/test/resources/org/switchyard/validate/internal/xml/sw-config-invalid-schemafile.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ JBoss, Home of Professional Open Source
+  ~ Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+  ~ as indicated by the @authors tag. All rights reserved.
+  ~ See the copyright.txt in the distribution for a
+  ~ full listing of individual contributors.
+  ~
+  ~ This copyrighted material is made available to anyone wishing to use,
+  ~ modify, copy, or redistribute it subject to the terms and conditions
+  ~ of the GNU Lesser General Public License, v. 2.1.
+  ~ This program is distributed in the hope that it will be useful, but WITHOUT A
+  ~ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+  ~ PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+  ~ You should have received a copy of the GNU Lesser General Public License,
+  ~ v.2.1 along with this distribution; if not, write to the Free Software
+  ~ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+  ~ MA  02110-1301, USA.
+  -->
+<switchyard xmlns="urn:switchyard-config:switchyard:1.0">
+    <validates>
+        <validate.xml xmlns="urn:switchyard-config:validate:1.0" schemaType="XML_SCHEMA" name="A" schemaFile="/org/switchyard/validate/internal/xml/person-invalid.xsd"/>
+    </validates>
+</switchyard>

--- a/validate/src/test/resources/org/switchyard/validate/internal/xml/sw-config-no-schemafile.xml
+++ b/validate/src/test/resources/org/switchyard/validate/internal/xml/sw-config-no-schemafile.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ JBoss, Home of Professional Open Source
+  ~ Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+  ~ as indicated by the @authors tag. All rights reserved.
+  ~ See the copyright.txt in the distribution for a
+  ~ full listing of individual contributors.
+  ~
+  ~ This copyrighted material is made available to anyone wishing to use,
+  ~ modify, copy, or redistribute it subject to the terms and conditions
+  ~ of the GNU Lesser General Public License, v. 2.1.
+  ~ This program is distributed in the hope that it will be useful, but WITHOUT A
+  ~ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+  ~ PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+  ~ You should have received a copy of the GNU Lesser General Public License,
+  ~ v.2.1 along with this distribution; if not, write to the Free Software
+  ~ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+  ~ MA  02110-1301, USA.
+  -->
+<switchyard xmlns="urn:switchyard-config:switchyard:1.0">
+    <validates>
+        <validate.xml xmlns="urn:switchyard-config:validate:1.0" schemaType="XML_SCHEMA" name="A" />
+    </validates>
+</switchyard>

--- a/validate/src/test/resources/org/switchyard/validate/internal/xml/sw-config-no-schematype.xml
+++ b/validate/src/test/resources/org/switchyard/validate/internal/xml/sw-config-no-schematype.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ JBoss, Home of Professional Open Source
+  ~ Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+  ~ as indicated by the @authors tag. All rights reserved.
+  ~ See the copyright.txt in the distribution for a
+  ~ full listing of individual contributors.
+  ~
+  ~ This copyrighted material is made available to anyone wishing to use,
+  ~ modify, copy, or redistribute it subject to the terms and conditions
+  ~ of the GNU Lesser General Public License, v. 2.1.
+  ~ This program is distributed in the hope that it will be useful, but WITHOUT A
+  ~ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+  ~ PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+  ~ You should have received a copy of the GNU Lesser General Public License,
+  ~ v.2.1 along with this distribution; if not, write to the Free Software
+  ~ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+  ~ MA  02110-1301, USA.
+  -->
+<switchyard xmlns="urn:switchyard-config:switchyard:1.0">
+    <validates>
+        <validate.xml xmlns="urn:switchyard-config:validate:1.0" name="A" schemaFile="/org/switchyard/validate/internal/xml/person.xsd" />
+    </validates>
+</switchyard>

--- a/validate/src/test/resources/org/switchyard/validate/internal/xml/sw-config-xmlv-01.xml
+++ b/validate/src/test/resources/org/switchyard/validate/internal/xml/sw-config-xmlv-01.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ JBoss, Home of Professional Open Source
+  ~ Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+  ~ as indicated by the @authors tag. All rights reserved.
+  ~ See the copyright.txt in the distribution for a
+  ~ full listing of individual contributors.
+  ~
+  ~ This copyrighted material is made available to anyone wishing to use,
+  ~ modify, copy, or redistribute it subject to the terms and conditions
+  ~ of the GNU Lesser General Public License, v. 2.1.
+  ~ This program is distributed in the hope that it will be useful, but WITHOUT A
+  ~ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+  ~ PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+  ~ You should have received a copy of the GNU Lesser General Public License,
+  ~ v.2.1 along with this distribution; if not, write to the Free Software
+  ~ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+  ~ MA  02110-1301, USA.
+  -->
+
+<switchyard xmlns="urn:switchyard-config:switchyard:1.0">
+    <validates>
+        <validate.xml xmlns="urn:switchyard-config:validate:1.0" schemaType="XML_SCHEMA" name="A" schemaFile="/org/switchyard/validate/internal/xml/person.xsd" />
+    </validates>
+</switchyard>


### PR DESCRIPTION
Original pull request: https://github.com/jboss-switchyard/core/pull/327

Changes:
Add CONTENT_TYPE and VALIDATED_TYPE property to indicate the current type of message contents and the type already validated.
CONTENT_TYPE is initialized by ExchangeImpl in the begininng of every Exchange, and will be replaced to newer one when transform occur.
VALIDATED_TYPE is added by ValidateHandler after validation occur. This is used to avoid to apply the same validator twice.
