### PR TITLE
SWITCHYARD-555

### DIFF
--- a/tools/forge/plugin/src/main/java/org/switchyard/tools/forge/plugin/SwitchYardPlugin.java
+++ b/tools/forge/plugin/src/main/java/org/switchyard/tools/forge/plugin/SwitchYardPlugin.java
@@ -18,11 +18,18 @@
  */
 package org.switchyard.tools.forge.plugin;
 
+import java.util.List;
+
 import javax.inject.Inject;
+
+import org.apache.maven.model.Dependency;
+import org.apache.maven.project.MavenProject;
+import org.jboss.forge.maven.MavenCoreFacet;
 
 import org.jboss.forge.project.Project;
 import org.jboss.forge.project.facets.MetadataFacet;
 import org.jboss.forge.project.facets.ResourceFacet;
+
 import org.jboss.forge.shell.PromptType;
 import org.jboss.forge.shell.Shell;
 import org.jboss.forge.shell.ShellColor;
@@ -51,6 +58,8 @@ import org.switchyard.config.model.domain.v1.V1HandlerModel;
 import org.switchyard.config.model.domain.v1.V1HandlersModel;
 import org.switchyard.config.model.switchyard.SwitchYardModel;
 
+import java.util.Iterator;
+
 /**
  * Project-level commands for SwitchYard applications.
  */
@@ -73,7 +82,7 @@ public class SwitchYardPlugin implements Plugin {
 
     @Inject
     private Shell _shell;
-
+    
     /**
      * List SwitchYard services available in the project.
      * @param verbose true to enable XML dump of config
@@ -164,6 +173,18 @@ public class SwitchYardPlugin implements Plugin {
     @Command(value = "get-version", help = "Show the version of SwitchYard used by this application.")
     public void getVersion(final PipeOut out) {
         String version = _project.getFacet(SwitchYardFacet.class).getVersion();
+        
+        MavenProject mavenProject = _project.getFacet(MavenCoreFacet.class).getMavenProject();
+        if ("".equals(version) || (version == null) && mavenProject != null) {
+            List<Dependency> deps = mavenProject.getDependencies();
+            Iterator itr = deps.iterator();
+            while (itr.hasNext()) {
+                Dependency dep = (Dependency) itr.next();
+                if ("org.switchyard".equals(dep.getGroupId()) && "switchyard-api".equals(dep.getArtifactId())) {
+                    version = dep.getVersion();
+                }
+            }            
+        }
         out.println("SwitchYard version " + version);
     }
     


### PR DESCRIPTION
Use the version of switchyard-api if the switchyard.version proerty doesn't exist.
