### PR TITLE
SWITCHYARD-591

### DIFF
--- a/build/src/main/resources/checkstyle/suppressions.xml
+++ b/build/src/main/resources/checkstyle/suppressions.xml
@@ -12,4 +12,6 @@
         choking and throwing an Exception -->	
     <suppress checks="[a-zA-Z0-9]*"
 	files="org/switchyard/tools/maven/plugins/switchyard/ConfigureMojo.java"/>
+    <suppress checks="ParameterNumber"
+        files="org/switchyard/tools/forge/bpm/BPMServicePlugin.java"/>
 </suppressions>


### PR DESCRIPTION
Add a temporary suppression for BPMServicePlugin and the number of parameters
used there.    Once SWITCHYARD-619 is solved, then this temporary suppression
should be removed.
