### PR TITLE
SWITCHYARD-226 Camel bindings need to support WSDL interface type

### DIFF
--- a/transform/src/main/resources/META-INF/switchyard/transforms.xml
+++ b/transform/src/main/resources/META-INF/switchyard/transforms.xml
@@ -53,6 +53,7 @@
     <trfm:transform.java from="java:java.io.Reader" to="java:org.w3c.dom.Document" class="org.switchyard.transform.ootb.xml.BasicDOMTransformer"/>
     <trfm:transform.java from="java:java.io.Reader" to="java:org.w3c.dom.Element"  class="org.switchyard.transform.ootb.xml.BasicDOMTransformer"/>
 
+    <trfm:transform.java from="java:java.io.InputStream" to="java:org.w3c.dom.Node" class="org.switchyard.transform.ootb.xml.BasicDOMTransformer"/>
     <trfm:transform.java from="java:java.io.InputStream" to="java:org.w3c.dom.Document" class="org.switchyard.transform.ootb.xml.BasicDOMTransformer"/>
     <trfm:transform.java from="java:java.io.InputStream" to="java:org.w3c.dom.Element"  class="org.switchyard.transform.ootb.xml.BasicDOMTransformer"/>
 


### PR DESCRIPTION
https://issues.jboss.org/browse/SWITCHYARD-226
