### PR TITLE
SWITCHYARD-913 JCA component fails to be built with empty M2 repo

### DIFF
--- a/test/pom.xml
+++ b/test/pom.xml
@@ -128,15 +128,22 @@
         </dependency>
         <dependency>
             <groupId>org.hornetq</groupId>
-            <artifactId>hornetq-core</artifactId>
-            <scope>compile</scope>
+            <artifactId>hornetq-ra</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.hornetq</groupId>
+            <artifactId>hornetq-core-client</artifactId>
         </dependency>
         <dependency>
             <groupId>org.hornetq</groupId>
             <artifactId>hornetq-jms-client</artifactId>
+        </dependency>
+         <dependency>
+            <groupId>org.hornetq</groupId>
+            <artifactId>hornetq-core</artifactId>
             <scope>compile</scope>
         </dependency>
-        <dependency>
+       <dependency>
             <groupId>org.hornetq</groupId>
             <artifactId>hornetq-jms</artifactId>
             <scope>compile</scope>


### PR DESCRIPTION
Fixed broken dependencies on HornetQ which is used by JCAMixIn
