### PR TITLE
SWITCHYARD-980: Reading configuration files with CDATA is broken

### DIFF
--- a/config/src/main/java/org/switchyard/config/DOMConfiguration.java
+++ b/config/src/main/java/org/switchyard/config/DOMConfiguration.java
@@ -44,6 +44,7 @@ import org.w3c.dom.Element;
 import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
+import org.w3c.dom.Text;
 
 /**
  * A DOM (Document Object Model) representation of a Configuration.
@@ -119,7 +120,12 @@ public class DOMConfiguration extends BaseConfiguration {
     @Override
     public String getValue() {
         Node text_node = getTextNode(false);
-        return text_node != null ? text_node.getNodeValue() : null;
+        if (text_node instanceof Text) {
+            return ((Text)text_node).getWholeText();
+        } else if (text_node != null) {
+            return text_node.getNodeValue();
+        }
+        return null;
     }
 
     /**

--- a/config/src/test/java/org/switchyard/config/ConfigurationTests.java
+++ b/config/src/test/java/org/switchyard/config/ConfigurationTests.java
@@ -46,6 +46,7 @@ public class ConfigurationTests {
     private static final String NAMESPACES_XML = "/org/switchyard/config/ConfigurationTests-Namespaces.xml";
     private static final String ORDER_CHILDREN_UNORDERED_XML = "/org/switchyard/config/ConfigurationTests-OrderChildren-Unordered.xml";
     private static final String ORDER_CHILDREN_ORDERED_XML = "/org/switchyard/config/ConfigurationTests-OrderChildren-Ordered.xml";
+    private static final String CDATA_VALUE_XML = "/org/switchyard/config/ConfigurationTests-CdataValue.xml";
 
     private ConfigurationPuller _cfg_puller;
     private StringPuller _str_puller;
@@ -152,4 +153,10 @@ public class ConfigurationTests {
         Assert.assertTrue(diff.toString(), diff.identical());
     }
 
+    @Test
+    public void testCdataValue() throws Exception {
+        Configuration config = _cfg_puller.pull(CDATA_VALUE_XML, getClass());
+        Assert.assertEquals("test-simple-value", config.getFirstChild("simple").getValue());
+        Assert.assertEquals("test-complex-value", config.getFirstChild("complex").getValue());
+    }
 }

--- a/config/src/test/resources/org/switchyard/config/ConfigurationTests-CdataValue.xml
+++ b/config/src/test/resources/org/switchyard/config/ConfigurationTests-CdataValue.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+JBoss, Home of Professional Open Source
+Copyright 20112 Red Hat Inc. and/or its affiliates and other contributors
+as indicated by the @authors tag. All rights reserved.
+See the copyright.txt in the distribution for a
+full listing of individual contributors.
+
+This copyrighted material is made available to anyone wishing to use,
+modify, copy, or redistribute it subject to the terms and conditions
+of the GNU Lesser General Public License, v. 2.1.
+This program is distributed in the hope that it will be useful, but WITHOUT A
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+You should have received a copy of the GNU Lesser General Public License,
+v.2.1 along with this distribution; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+MA  02110-1301, USA.
+-->
+<root>
+    <simple>test-simple-value</simple>>
+    <complex>test-<![CDATA[complex]]>-value</complex>
+</root>


### PR DESCRIPTION
SWITCHYARD-980: Reading configuration files with CDATA is broken
https://issues.jboss.org/browse/SWITCHYARD-980
