### PR TITLE
SWITCHYARD-1087 Operation not found on ServiceReferenceImpl#createExchan...

### DIFF
--- a/runtime/src/main/java/org/switchyard/internal/ServiceReferenceImpl.java
+++ b/runtime/src/main/java/org/switchyard/internal/ServiceReferenceImpl.java
@@ -130,8 +130,14 @@ public class ServiceReferenceImpl implements ServiceReference {
         ExchangeImpl ex = new ExchangeImpl(_domain, handler);
         ServiceOperation op = _interface.getOperation(operation);
         if (op == null) {
-            throw new SwitchYardException("Operation " + operation + " does not exist for service " + _name);
+            // try for a default operation
+            if (_interface.getOperations().size() == 1) {
+                op = _interface.getOperations().iterator().next();
+            } else {
+                throw new SwitchYardException("Operation " + operation + " does not exist for service " + _name);
+            }
         }
+
         ex.consumer(this, op);
         ex.setOutputDispatcher(_dispatcher);
         


### PR DESCRIPTION
...ge()

Since interface.esb only puts an empty operation name into ServiceInterface, we need to pick it up but not only exact matched operation.
