### PR TITLE
SWITCHYARD-1094 Clean up namingmixin on uninitialise. Fix running Transa...

### DIFF
--- a/test/src/main/java/org/switchyard/test/mixins/NamingMixIn.java
+++ b/test/src/main/java/org/switchyard/test/mixins/NamingMixIn.java
@@ -89,6 +89,15 @@ public class NamingMixIn extends AbstractTestMixIn {
 
     @Override
     public void uninitialize() {
+        try
+        {
+            initialContext.destroySubcontext( "java:comp" );
+        }
+        catch ( NamingException e )
+        {
+            Assert.fail("Failed to destroy context : " + e.getMessage());
+        }
         NamingContext.setActiveNamingStore(new InMemoryNamingStore());
+        initialContext = null;
     }
 }

--- a/test/src/test/java/org/switchyard/test/mixins/TransactionMixInTest.java
+++ b/test/src/test/java/org/switchyard/test/mixins/TransactionMixInTest.java
@@ -37,17 +37,21 @@ import org.junit.Test;
  */
 public class TransactionMixInTest {
 
-    private static TransactionMixIn mixin;
+    private static NamingMixIn namingMixIn;
+    private static TransactionMixIn transactionMixin;
 
     @BeforeClass
     public static void setup() {
-        mixin = new TransactionMixIn();
-        mixin.initialize();
+        namingMixIn = new NamingMixIn();
+        namingMixIn.initialize();
+        transactionMixin = new TransactionMixIn();
+        transactionMixin.initialize();
     }
     
     @AfterClass
     public static void tearDown() {
-        mixin.uninitialize();
+        transactionMixin.uninitialize();
+        namingMixIn.uninitialize();
     }
 
     @Test
@@ -60,7 +64,7 @@ public class TransactionMixInTest {
 
     @Test
     public void shouldUseSameInstance() throws Exception {
-        assertSame(getUserTransaction(), mixin.getUserTransaction());
+        assertSame(getUserTransaction(), transactionMixin.getUserTransaction());
     }
 
     private UserTransaction getUserTransaction() throws NamingException {


### PR DESCRIPTION
...ctionMixInTest standalone.

( Running TransactionMixInTest standalone failed as NamingMixIn did not seem to be initialised. Lukasz thought NamingMixIn uninitialise was missing some bits as well).
