### PR TITLE
SWITCHYARD-718 forge tooling requires switchyard.version property in pom...

### DIFF
--- a/tools/forge/common/src/main/java/org/switchyard/tools/forge/AbstractFacet.java
+++ b/tools/forge/common/src/main/java/org/switchyard/tools/forge/AbstractFacet.java
@@ -62,13 +62,17 @@ public abstract class AbstractFacet extends BaseFacet {
 
     @Override
     public boolean isInstalled() {
+        PackagingType packagingType = project.getFacet(PackagingFacet.class).getPackagingType();
         boolean installed = false;
-        // If the first dependency is present then we assume the facet is installed
-        if (!_depends.isEmpty()) {
-            Dependency dep = DependencyBuilder.create(_depends.get(0));
-            PackagingType packagingType = project.getFacet(PackagingFacet.class).getPackagingType();
-            installed = project.getFacet(DependencyFacet.class).hasDirectDependency(dep)
-                    && PackagingType.JAR.equals(packagingType);
+        if (PackagingType.JAR.equals(packagingType)) {
+            installed = true;
+            for (String dependency : _depends) {
+                Dependency dep = DependencyBuilder.create(dependency);
+                if (!project.getFacet(DependencyFacet.class).hasDirectDependency(dep)) {
+                    installed = false;
+                    break;
+                }
+            }
         }
         return installed;
     }

--- a/tools/forge/plugin/src/main/java/org/switchyard/tools/forge/plugin/SwitchYardFacet.java
+++ b/tools/forge/plugin/src/main/java/org/switchyard/tools/forge/plugin/SwitchYardFacet.java
@@ -117,6 +117,16 @@ public class SwitchYardFacet extends AbstractFacet {
         }
     }
     
+    @Override
+    public boolean isInstalled() {
+        boolean installed = super.isInstalled();
+        if (installed && getVersion() == null) {
+            // Taking care of the case that project exists but POM doesn't have ${switchyard.version} property.
+            setVersion(Versions.getSwitchYardVersion());
+        }
+        return installed;
+    }
+    
     /**
      * Save the current SwitchYard configuration model.
      */


### PR DESCRIPTION
... for certain paths

This is the alternative to https://github.com/jboss-switchyard/core/pull/427

If the SwitchYard application project doesn't have ${switchyard.version} in POM, forge throws an Exception at startup time. So we need to add this property once it turns out the project contains SwitchYard application.

Since the tools/forge/plugin/pom.xml is assumed as SwitchYardFacet installed in the test case and always tries to add ${switchyard.version} into this pom.xml by this change, I added the property so that we can avoid it on every build.
