### PR TITLE
SWITCHYARD-1121 Running CDIMixInStopStartTest by itself fails.

### DIFF
--- a/test/src/test/java/org/switchyard/test/mixins/CDIMixInStopStartTest.java
+++ b/test/src/test/java/org/switchyard/test/mixins/CDIMixInStopStartTest.java
@@ -31,9 +31,12 @@ public class CDIMixInStopStartTest {
 
     @Test
     public void test() {
-        CDIMixIn mixIn = new CDIMixIn();
+        NamingMixIn namingMixIn = new NamingMixIn();
+        CDIMixIn cdiMixIn = new CDIMixIn();
 
-        mixIn.initialize();
-        mixIn.uninitialize();
+        namingMixIn.initialize();
+        cdiMixIn.initialize();
+        cdiMixIn.uninitialize();
+        namingMixIn.uninitialize();
     }
 }


### PR DESCRIPTION
Initialised/Uninitialised the NamingMixIn to solve the problem.
