### PR TITLE
SWITCHYARD-718 forge tooling requires switchyard.version property in pom...

### DIFF
--- a/tools/forge/plugin/src/main/java/org/switchyard/tools/forge/plugin/SwitchYardFacet.java
+++ b/tools/forge/plugin/src/main/java/org/switchyard/tools/forge/plugin/SwitchYardFacet.java
@@ -117,6 +117,19 @@ public class SwitchYardFacet extends AbstractFacet {
         }
     }
     
+    @Override
+    public boolean isInstalled() {
+        // checking switchyard.xml existence and if the POM has dependency on switchyard-api 
+        if (super.isInstalled() && getSwitchYardConfigFile().exists()) {
+            if (getVersion() == null) {
+                // If it's switchyard project but POM doesn't have ${switchyard.version} property, add it.
+                setVersion(Versions.getSwitchYardVersion());
+            }
+        return true;
+        }
+        return false;
+    }
+    
     /**
      * Save the current SwitchYard configuration model.
      */


### PR DESCRIPTION
... for certain paths

3rd try for the SWITCHYARD-718 - alternative to https://github.com/jboss-switchyard/core/pull/434

switchyard.xml existence check Keith suggested works perfectly.
