### PR TITLE
SWITCHYARD-1149 Forge improvement

### DIFF
--- a/api/src/main/java/org/switchyard/policy/PolicyFactory.java
+++ b/api/src/main/java/org/switchyard/policy/PolicyFactory.java
@@ -21,8 +21,11 @@
 package org.switchyard.policy;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
+
+import org.switchyard.policy.Policy.PolicyType;
 
 /**
  * A factory class for the policies.
@@ -32,6 +35,7 @@ public final class PolicyFactory {
     private PolicyFactory() {}
     
     private static Set<Policy> _policies;
+
     static {
         _policies = new HashSet<Policy>();
         _policies.addAll(Arrays.asList(TransactionPolicy.values()));
@@ -51,5 +55,41 @@ public final class PolicyFactory {
             }
         }
         throw new Exception("Invalid policy name: '" + name + "' doesn't exist.");
+    }
+    
+    /**
+     * Returns a set of all available policies.
+     * @return policies
+     */
+    public static Set<Policy> getAllAvailablePolicies() {
+        return Collections.unmodifiableSet(_policies);
+    }
+    
+    /**
+     * Returns a set of available interaction policies.
+     * @return policies
+     */
+    public static Set<Policy> getAvailableInteractionPolicies() {
+        Set<Policy> interactions = new HashSet<Policy>();
+        for (Policy p : _policies) {
+            if (p.getType().equals(PolicyType.INTERACTION)) {
+                interactions.add(p);
+            }
+        }
+        return Collections.unmodifiableSet(interactions);
+    }
+    
+    /**
+     * Returns a set of available implementation policies.
+     * @return policies
+     */
+    public static Set<Policy> getAvailableImplementationPolicies() {
+        Set<Policy> implementations = new HashSet<Policy>();
+        for (Policy p : _policies) {
+            if (p.getType().equals(PolicyType.IMPLEMENTATION)) {
+                implementations.add(p);
+            }
+        }
+        return Collections.unmodifiableSet(implementations);
     }
 }

--- a/config/src/main/java/org/switchyard/config/model/composer/ContextMapperModel.java
+++ b/config/src/main/java/org/switchyard/config/model/composer/ContextMapperModel.java
@@ -32,17 +32,17 @@ public interface ContextMapperModel extends Model {
     public static final String CONTEXT_MAPPER = "contextMapper";
 
     /**
-     * Gets the type of ContextMapper.
-     * @return the type of ContextMapper
+     * Gets the fully qualified class name of ContextMapper.
+     * @return the fully qualified class name of ContextMapper
      */
-    public Class<?> getClazz();
+    public String getClazz();
 
     /**
-     * Sets the type of ContextMapper.
-     * @param clazz the  the type of ContextMapper
+     * Sets the fully qualified class name of ContextMapper.
+     * @param clazz the fully qualified class name of ContextMapper
      * @return this instance (useful for chaining)
      */
-    public ContextMapperModel setClazz(Class<?> clazz);
+    public ContextMapperModel setClazz(String clazz);
 
     /**
      * Gets the comma-separated list of regex property includes.

--- a/config/src/main/java/org/switchyard/config/model/composer/MessageComposerModel.java
+++ b/config/src/main/java/org/switchyard/config/model/composer/MessageComposerModel.java
@@ -32,16 +32,16 @@ public interface MessageComposerModel extends Model {
     public static final String MESSAGE_COMPOSER = "messageComposer";
 
     /**
-     * Gets the type of ContextMapper.
-     * @return the type of ContextMapper
+     * Gets the fully qualified class name of ContextMapper.
+     * @return the fully qualified class name of ContextMapper
      */
-    public Class<?> getClazz();
+    public String getClazz();
 
     /**
-     * Sets the type of ContextMapper.
-     * @param clazz type of ContextMapper
+     * Sets the fully qualified class name of ContextMapper.
+     * @param clazz fully qualified class name of ContextMapper
      * @return this instance (useful for chaining)
      */
-    public MessageComposerModel setClazz(Class<?> clazz);
+    public MessageComposerModel setClazz(String clazz);
 
 }

--- a/config/src/main/java/org/switchyard/config/model/composer/v1/V1ContextMapperModel.java
+++ b/config/src/main/java/org/switchyard/config/model/composer/v1/V1ContextMapperModel.java
@@ -22,7 +22,6 @@ package org.switchyard.config.model.composer.v1;
 import javax.xml.namespace.QName;
 
 import org.switchyard.common.lang.Strings;
-import org.switchyard.common.type.Classes;
 import org.switchyard.config.Configuration;
 import org.switchyard.config.model.BaseModel;
 import org.switchyard.config.model.Descriptor;
@@ -64,20 +63,16 @@ public class V1ContextMapperModel extends BaseModel implements ContextMapperMode
      * {@inheritDoc}
      */
     @Override
-    public Class<?> getClazz() {
-        String name = Strings.trimToNull(getModelAttribute("class"));
-        if (name != null) {
-            return Classes.forName(name, getClass());
-        }
-        return null;
+    public String getClazz() {
+        return Strings.trimToNull(getModelAttribute("class"));
     }
 
     /**
      * {@inheritDoc}
      */
     @Override
-    public ContextMapperModel setClazz(Class<?> clazz) {
-        setModelAttribute("class", clazz != null ? clazz.getName() : null);
+    public ContextMapperModel setClazz(String clazz) {
+        setModelAttribute("class", clazz);
         return this;
     }
 

--- a/config/src/main/java/org/switchyard/config/model/composer/v1/V1MessageComposerModel.java
+++ b/config/src/main/java/org/switchyard/config/model/composer/v1/V1MessageComposerModel.java
@@ -22,7 +22,6 @@ package org.switchyard.config.model.composer.v1;
 import javax.xml.namespace.QName;
 
 import org.switchyard.common.lang.Strings;
-import org.switchyard.common.type.Classes;
 import org.switchyard.config.Configuration;
 import org.switchyard.config.model.BaseModel;
 import org.switchyard.config.model.Descriptor;
@@ -64,20 +63,16 @@ public class V1MessageComposerModel extends BaseModel implements MessageComposer
      * {@inheritDoc}
      */
     @Override
-    public Class<?> getClazz() {
-        String name = Strings.trimToNull(getModelAttribute("class"));
-        if (name != null) {
-            return Classes.forName(name, getClass());
-        }
-        return null;
+    public String getClazz() {
+        return Strings.trimToNull(getModelAttribute("class"));
     }
 
     /**
      * {@inheritDoc}
      */
     @Override
-    public MessageComposerModel setClazz(Class<?> clazz) {
-        setModelAttribute("class", clazz != null ? clazz.getName() : null);
+    public MessageComposerModel setClazz(String clazz) {
+        setModelAttribute("class", clazz);
         return this;
     }
 

--- a/config/src/main/java/org/switchyard/config/model/composite/BindingModel.java
+++ b/config/src/main/java/org/switchyard/config/model/composite/BindingModel.java
@@ -85,4 +85,17 @@ public interface BindingModel extends TypedModel {
      */
     public MessageComposerModel getMessageComposer();
 
+    /**
+     * Sets the child context mapper model.
+     * @param model the context mapper model to set
+     * @return this BindingModel (useful for chaining)
+     */
+    public BindingModel setContextMapper(ContextMapperModel model);
+    
+    /**
+     * Sets the child message composer model.
+     * @param model the message composer model to set
+     * @return this BindingModel (useful for chaining)
+     */
+    public BindingModel setMessageComposer(MessageComposerModel model);
 }

--- a/config/src/main/java/org/switchyard/config/model/composite/v1/V1BindingModel.java
+++ b/config/src/main/java/org/switchyard/config/model/composite/v1/V1BindingModel.java
@@ -146,6 +146,26 @@ public class V1BindingModel extends BaseTypedModel implements BindingModel {
         return _messageComposer;
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public BindingModel setContextMapper(ContextMapperModel model) {
+        _contextMapper = model;
+        setChildModel(model);
+        return this;
+    }
+    
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public BindingModel setMessageComposer(MessageComposerModel model) {
+        _messageComposer = model;
+        setChildModel(model);
+        return this;
+    }
+    
     @Override
     public boolean isServiceBinding() {
         return (getModelParent() instanceof CompositeServiceModel);

--- a/tools/forge/plugin/pom.xml
+++ b/tools/forge/plugin/pom.xml
@@ -83,6 +83,14 @@
             <groupId>org.switchyard</groupId>
             <artifactId>switchyard-forge-common</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.switchyard</groupId>
+            <artifactId>switchyard-transform</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.switchyard</groupId>
+            <artifactId>switchyard-validate</artifactId>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/tools/forge/plugin/src/main/java/org/switchyard/tools/forge/plugin/SwitchYardFacet.java
+++ b/tools/forge/plugin/src/main/java/org/switchyard/tools/forge/plugin/SwitchYardFacet.java
@@ -444,7 +444,11 @@ public class SwitchYardFacet extends AbstractFacet {
         }
         File backup = new File(asConfigPath + ".orig");
         if (backup.exists()) {
-            throw new Exception("backup standalone.xml already exists " + backup.getAbsolutePath());
+            if (_shell.promptBoolean("backup standalone.xml '" + backup.getAbsolutePath() + "' already exists: remove it?")) {
+                backup.delete();
+            } else {
+                throw new Exception("backup standalone.xml already exists " + backup.getAbsolutePath());
+            }
         }
         if (!orig.renameTo(backup)) {
             throw new Exception("Failed to create backup standalone.xml " + backup.getAbsolutePath());


### PR DESCRIPTION
- SWITCHYARD-995 Added JCA, Remote binding plugin
- SWITCHYARD-1072 Added HornetQ binding plugin
- SWITCHYARD-1073 Added add-operation-selector, add-transformer, add-validator, add-required-policy to the SwitchYardPlugin
- SWITCHYARD-1074 Added Common component plugin which supports add-context-mapper and add-message-composer
- SWITCHYARD-1166 Remove the standalone.xml.orig with user confirmation instead of error
