### PR TITLE
SWITCHYARD-1193 Set the relatesTo property on the fault response

### DIFF
--- a/runtime/src/main/java/org/switchyard/internal/ExchangeImpl.java
+++ b/runtime/src/main/java/org/switchyard/internal/ExchangeImpl.java
@@ -127,6 +127,10 @@ public class ExchangeImpl implements Exchange {
         _state = ExchangeState.FAULT;
         initFaultContentType();
         
+        // set relatesTo header on OUT context
+        _context.setProperty(RELATES_TO, _context.getProperty(
+                MESSAGE_ID, Scope.IN).getValue(), Scope.OUT);
+
         sendInternal(message);
     }
 


### PR DESCRIPTION
Required to correlate fault responses to the originating request.
