### PR TITLE
SWITCHYARD-1223 Extract the root causes when a Throwable is sent as Faul...

### DIFF
--- a/transform/src/main/java/org/switchyard/transform/ootb/lang/ExceptionTransforms.java
+++ b/transform/src/main/java/org/switchyard/transform/ootb/lang/ExceptionTransforms.java
@@ -1,0 +1,47 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+package org.switchyard.transform.ootb.lang;
+
+import org.switchyard.annotations.Transformer;
+
+/**
+ * Exception transforms.
+ */
+public class ExceptionTransforms {
+
+    /**
+     * Singleton Instance.
+     */
+    public static final ExceptionTransforms TRANSFORMER = new ExceptionTransforms();
+
+    /**
+     * Transform to String.
+     * @param t Exception to extract
+     * @return String.
+     */
+    @Transformer
+    public String toString(Throwable t) {
+        Throwable cause = t;
+        String result = cause.getClass().getName() + ": " + cause.getMessage();
+        while ((cause = cause.getCause()) != null) {
+            result += " --- Caused by " + cause.getClass().getName() + ": " + cause.getMessage();
+        }
+        return result;
+    }
+}

--- a/transform/src/main/resources/META-INF/switchyard/transforms.xml
+++ b/transform/src/main/resources/META-INF/switchyard/transforms.xml
@@ -76,6 +76,9 @@
     <!-- Number transforms... -->
     <trfm:transform.java from="java:java.lang.Number" to="*" class="org.switchyard.transform.ootb.lang.NumberTransforms" />
 
+    <!-- Exception transforms... -->
+    <trfm:transform.java from="java:java.lang.Throwable" to="java:java.lang.String" class="org.switchyard.transform.ootb.lang.ExceptionTransforms" />
+
     <!-- Reader transforms... -->
     <trfm:transform.java from="java:java.io.Reader" to="*" class="org.switchyard.transform.ootb.io.ReaderTransforms" />
 

--- a/transform/src/test/java/org/switchyard/transform/ootb/lang/ExceptionTransformsTest.java
+++ b/transform/src/test/java/org/switchyard/transform/ootb/lang/ExceptionTransformsTest.java
@@ -1,0 +1,35 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *  *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+
+package org.switchyard.transform.ootb.lang;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * ExceptionTransforms test.
+ */
+public class ExceptionTransformsTest {
+
+    @Test
+    public void testToString() throws Exception {
+        Assert.assertEquals("java.lang.Exception: level-1 --- Caused by java.lang.IllegalStateException: level-2 --- Caused by java.lang.NullPointerException: level-3",
+                new ExceptionTransforms().toString(new Exception("level-1", new IllegalStateException("level-2", new NullPointerException("level-3")))));
+    }
+}


### PR DESCRIPTION
...t message without reply handler

We can see the ExchangeImpl gives us a message which includes root cause on this testcase,  ExchangeImplTest#testFaultWithNoHandler()
