### PR TITLE
SWITCHYARD-1231 operationSelector gets clobbered with multiple camel bindings on a service

### DIFF
--- a/common-camel/src/main/java/org/switchyard/common/camel/SwitchYardCamelContext.java
+++ b/common-camel/src/main/java/org/switchyard/common/camel/SwitchYardCamelContext.java
@@ -58,9 +58,23 @@ public class SwitchYardCamelContext extends DefaultCamelContext {
     private AtomicInteger _count = new AtomicInteger();
 
     /**
+     * Flag to turn on/off cdi integration.
+     */
+    private boolean _cdiIntegration;
+
+    /**
      * Creates new camel context.
      */
     public SwitchYardCamelContext() {
+        this(true);
+    }
+
+    /**
+     * Creates new camel context.
+     * @param autoDetectCdi Should cdi integration be auto detected and enabled.
+     */
+    public SwitchYardCamelContext(boolean autoDetectCdi) {
+        _cdiIntegration = autoDetectCdi;
         if (isEnableCdiIntegration()) {
             setInjector(new CdiInjector(getInjector()));
             getManagementStrategy().addEventNotifier(new CamelEventBridge());
@@ -149,7 +163,10 @@ public class SwitchYardCamelContext extends DefaultCamelContext {
      * 
      * @return True if CDI runtime is detected.
      */
-    private boolean isEnableCdiIntegration() {
+    public boolean isEnableCdiIntegration() {
+        if (!_cdiIntegration) {
+            return false;
+        }
         try {
             BeanManagerProvider.getInstance();
             return true;

--- a/common/src/main/java/org/switchyard/common/xml/QNameUtil.java
+++ b/common/src/main/java/org/switchyard/common/xml/QNameUtil.java
@@ -19,9 +19,13 @@
 
 package org.switchyard.common.xml;
 
-import org.switchyard.common.type.Classes;
+import java.lang.reflect.Array;
+import java.util.Arrays;
+import java.util.List;
 
 import javax.xml.namespace.QName;
+
+import org.switchyard.common.type.Classes;
 
 /**
  * QName utility methods.
@@ -37,11 +41,18 @@ public final class QNameUtil {
      *  Java message type.
      */
     public static final String JAVA_TYPE = "java";
+
     /**
      * Java Type prefix.
      */
     private static final String JAVA_TYPE_PREFIX = JAVA_TYPE + ":";
 
+    /**
+     * Primitive array types.
+     */
+    private static final List<String> PRIMITIVES = Arrays.asList(
+        "byte[]", "short[]", "int[]", "long[]", "float[]", "double[]", "boolean[]", "char[]"
+    );
 
     /**
      * Is the specified message type QName a Java message type.
@@ -63,6 +74,10 @@ public final class QNameUtil {
         }
 
         String className = name.getLocalPart().substring(JAVA_TYPE_PREFIX.length());
+        if (!PRIMITIVES.contains(className) && className.contains("[]")) {
+            className = className.substring(0, className.length() - 2);
+            return Array.newInstance(Classes.forName(className), 0).getClass();
+        }
         return Classes.forName(className);
     }
 }


### PR DESCRIPTION
Chages necessary to get unit tests running without fails.
