### PR TITLE
SWITCHYARD-1268: Add support for system property and domain property replacement across switchyard config

### DIFF
--- a/common/src/main/java/org/switchyard/common/io/resource/BaseResource.java
+++ b/common/src/main/java/org/switchyard/common/io/resource/BaseResource.java
@@ -77,8 +77,6 @@ public abstract class BaseResource implements Resource {
 
     private static final URL getURL(String location, Class<?> caller, ClassLoader loader) {
         if (location != null) {
-            // TODO: we don't want to depend on this library, so write our own property replacer?
-            //location = StrSubstitutor.replaceSystemProperties(location);
             try {
                 if (location.startsWith("http:") || location.startsWith("https:")) {
                     return new URL(location);

--- a/common/src/main/java/org/switchyard/common/lang/Strings.java
+++ b/common/src/main/java/org/switchyard/common/lang/Strings.java
@@ -28,6 +28,9 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.StringTokenizer;
 
+import org.switchyard.common.property.PropertyResolver;
+import org.switchyard.common.property.SystemPropertiesPropertyResolver;
+
 /**
  * Common String Utilities.
  *
@@ -228,6 +231,47 @@ public final class Strings {
             return sb.toString();
         }
         return null;
+    }
+
+    /**
+     * Replaces system properties.
+     * @param str the original string
+     * @return the modified string
+     */
+    public static String replaceSystemProperties(String str) {
+        return replaceProperties(str, SystemPropertiesPropertyResolver.instance());
+    }
+
+    /**
+     * Replaces properties per the given property resolver.
+     * @param str the original string
+     * @param resolver the property resolver
+     * @return the modified string
+     */
+    public static String replaceProperties(String str, PropertyResolver resolver) {
+        if (str != null && resolver != null) {
+            int l_pos = str.indexOf("${", 0);
+            while (l_pos != -1) {
+                int r_pos = str.indexOf('}', l_pos + 2);
+                if (r_pos == -1) {
+                    break;
+                }
+                String key = str.substring(l_pos + 2, r_pos);
+                String value = resolver.resolveProperty(key);
+                if (value != null) {
+                    String begin = str.substring(0, l_pos);
+                    str = new StringBuilder()
+                        .append(begin)
+                        .append(value)
+                        .append(str.substring(r_pos + 1, str.length()))
+                        .toString();
+                    l_pos = str.indexOf("${", begin.length() + value.length());
+                } else {
+                    l_pos = str.indexOf("${", l_pos + 2);
+                }
+            }
+        }
+        return str;
     }
 
     private Strings() {}

--- a/common/src/main/java/org/switchyard/common/property/CompoundPropertyResolver.java
+++ b/common/src/main/java/org/switchyard/common/property/CompoundPropertyResolver.java
@@ -1,0 +1,77 @@
+/* 
+ * JBoss, Home of Professional Open Source 
+ * Copyright 2012 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved. 
+ * See the copyright.txt in the distribution for a 
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use, 
+ * modify, copy, or redistribute it subject to the terms and conditions 
+ * of the GNU Lesser General Public License, v. 2.1. 
+ * This program is distributed in the hope that it will be useful, but WITHOUT A 
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details. 
+ * You should have received a copy of the GNU Lesser General Public License, 
+ * v.2.1 along with this distribution; if not, write to the Free Software 
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, 
+ * MA  02110-1301, USA.
+ */
+package org.switchyard.common.property;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * Resolves properties from multiple sources.
+ *
+ * @author David Ward &lt;<a href="mailto:dward@jboss.org">dward@jboss.org</a>&gt; &copy; 2012 Red Hat Inc.
+ */
+public class CompoundPropertyResolver implements PropertyResolver {
+
+    private List<PropertyResolver> _resolvers = new ArrayList<PropertyResolver>();
+
+    /**
+     * Construction with a variable array of property resolvers.
+     * @param resolvers the property resolvers
+     */
+    public CompoundPropertyResolver(PropertyResolver... resolvers) {
+        if (resolvers != null) {
+            for (PropertyResolver resolver : resolvers) {
+                if (resolver != null && !_resolvers.contains(resolver) && resolver != this) {
+                    _resolvers.add(resolver);
+                }
+            }
+        }
+    }
+
+    /**
+     * Construction with a collection of property resolvers.
+     * @param resolvers the property resolvers
+     */
+    public CompoundPropertyResolver(Collection<PropertyResolver> resolvers) {
+        if (resolvers != null) {
+            for (PropertyResolver resolver : resolvers) {
+                if (resolver != null && !_resolvers.contains(resolver) && resolver != this) {
+                    _resolvers.add(resolver);
+                }
+            }
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String resolveProperty(String key) {
+        String value = null;
+        for (PropertyResolver resolver : _resolvers) {
+            value = resolver.resolveProperty(key);
+            if (value != null) {
+                break;
+            }
+        }
+        return value;
+    }
+
+}

--- a/common/src/main/java/org/switchyard/common/property/PropertiesPropertyResolver.java
+++ b/common/src/main/java/org/switchyard/common/property/PropertiesPropertyResolver.java
@@ -1,0 +1,48 @@
+/* 
+ * JBoss, Home of Professional Open Source 
+ * Copyright 2012 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved. 
+ * See the copyright.txt in the distribution for a 
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use, 
+ * modify, copy, or redistribute it subject to the terms and conditions 
+ * of the GNU Lesser General Public License, v. 2.1. 
+ * This program is distributed in the hope that it will be useful, but WITHOUT A 
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details. 
+ * You should have received a copy of the GNU Lesser General Public License, 
+ * v.2.1 along with this distribution; if not, write to the Free Software 
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, 
+ * MA  02110-1301, USA.
+ */
+package org.switchyard.common.property;
+
+import java.util.Properties;
+
+/**
+ * Resolves properties from Properties.
+ *
+ * @author David Ward &lt;<a href="mailto:dward@jboss.org">dward@jboss.org</a>&gt; &copy; 2012 Red Hat Inc.
+ */
+public class PropertiesPropertyResolver implements PropertyResolver {
+
+    private final Properties _properties;
+
+    /**
+     * Construction with the specified Properties.
+     * @param properties the specified Properties
+     */
+    public PropertiesPropertyResolver(Properties properties) {
+        _properties = properties;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public final String resolveProperty(String key) {
+        return _properties.getProperty(key);
+    }
+
+}

--- a/common/src/main/java/org/switchyard/common/property/PropertyResolver.java
+++ b/common/src/main/java/org/switchyard/common/property/PropertyResolver.java
@@ -1,0 +1,35 @@
+/* 
+ * JBoss, Home of Professional Open Source 
+ * Copyright 2012 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved. 
+ * See the copyright.txt in the distribution for a 
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use, 
+ * modify, copy, or redistribute it subject to the terms and conditions 
+ * of the GNU Lesser General Public License, v. 2.1. 
+ * This program is distributed in the hope that it will be useful, but WITHOUT A 
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details. 
+ * You should have received a copy of the GNU Lesser General Public License, 
+ * v.2.1 along with this distribution; if not, write to the Free Software 
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, 
+ * MA  02110-1301, USA.
+ */
+package org.switchyard.common.property;
+
+/**
+ * Resolves properties.
+ *
+ * @author David Ward &lt;<a href="mailto:dward@jboss.org">dward@jboss.org</a>&gt; &copy; 2012 Red Hat Inc.
+ */
+public interface PropertyResolver {
+
+    /**
+     * Resolves a property.
+     * @param key the property key
+     * @return the property value
+     */
+    public String resolveProperty(String key);
+
+}

--- a/common/src/main/java/org/switchyard/common/property/SystemPropertiesPropertyResolver.java
+++ b/common/src/main/java/org/switchyard/common/property/SystemPropertiesPropertyResolver.java
@@ -1,0 +1,58 @@
+/* 
+ * JBoss, Home of Professional Open Source 
+ * Copyright 2012 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved. 
+ * See the copyright.txt in the distribution for a 
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use, 
+ * modify, copy, or redistribute it subject to the terms and conditions 
+ * of the GNU Lesser General Public License, v. 2.1. 
+ * This program is distributed in the hope that it will be useful, but WITHOUT A 
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details. 
+ * You should have received a copy of the GNU Lesser General Public License, 
+ * v.2.1 along with this distribution; if not, write to the Free Software 
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, 
+ * MA  02110-1301, USA.
+ */
+package org.switchyard.common.property;
+
+import java.util.Properties;
+
+import org.apache.log4j.Logger;
+
+/**
+ * Resolves properties from System Properties.
+ *
+ * @author David Ward &lt;<a href="mailto:dward@jboss.org">dward@jboss.org</a>&gt; &copy; 2012 Red Hat Inc.
+ */
+public final class SystemPropertiesPropertyResolver extends PropertiesPropertyResolver {
+
+    private static final Logger LOGGER = Logger.getLogger(SystemPropertiesPropertyResolver.class);
+
+    private static final SystemPropertiesPropertyResolver INSTANCE;
+    static {
+        Properties systemProperties;
+        try {
+            systemProperties = System.getProperties();
+        } catch (SecurityException se) {
+            LOGGER.error("SecurityException while getting System Properties; will default to empty Properties", se);
+            systemProperties = new Properties();
+        }
+        INSTANCE = new SystemPropertiesPropertyResolver(systemProperties);
+    }
+
+    private SystemPropertiesPropertyResolver(Properties systemProperties) {
+        super(systemProperties);
+    }
+
+    /**
+     * Returns the singleton instance.
+     * @return the singleton instance
+     */
+    public static final SystemPropertiesPropertyResolver instance() {
+        return INSTANCE;
+    }
+
+}

--- a/common/src/test/java/org/switchyard/common/lang/StringsTests.java
+++ b/common/src/test/java/org/switchyard/common/lang/StringsTests.java
@@ -29,9 +29,15 @@ import static org.switchyard.common.lang.Strings.uniqueSplitTrimToNullArray;
 
 import java.util.Iterator;
 import java.util.List;
+import java.util.Properties;
 import java.util.Set;
 
+import org.junit.Assert;
 import org.junit.Test;
+import org.switchyard.common.property.CompoundPropertyResolver;
+import org.switchyard.common.property.PropertiesPropertyResolver;
+import org.switchyard.common.property.PropertyResolver;
+import org.switchyard.common.property.SystemPropertiesPropertyResolver;
 
 /**
  * StringsTests.
@@ -95,6 +101,35 @@ public class StringsTests {
         assertEquals(2, s.length);
         assertEquals("foo", s[0]);
         assertEquals("bar", s[1]);
+    }
+
+    @Test
+    public void testReplaceSystemProperties() {
+        final String original = "Hello ${user.name} using ${os.name} skipping ${unknown.property}!";
+        final String expected = "Hello " + System.getProperty("user.name") + " using " + System.getProperty("os.name") + " skipping ${unknown.property}!";
+        final String actual = Strings.replaceSystemProperties(original);
+        Assert.assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testReplaceCustomProperties() {
+        Properties custom = new Properties();
+        custom.setProperty("foo", "bar");
+        final String original = "I have a ${foo}.";
+        final String expected = "I have a bar.";
+        final String actual = Strings.replaceProperties(original, new PropertiesPropertyResolver(custom));
+        Assert.assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testReplaceCompoundProperties() {
+        Properties custom = new Properties();
+        custom.setProperty("foo", "bar");
+        final String original = "${user.name} has a ${foo}.";
+        final String expected = System.getProperty("user.name") + " has a bar.";
+        PropertyResolver resolver = new CompoundPropertyResolver(SystemPropertiesPropertyResolver.instance(), new PropertiesPropertyResolver(custom));
+        final String actual = Strings.replaceProperties(original, resolver);
+        Assert.assertEquals(expected, actual);
     }
 
 }

--- a/config/src/main/java/org/switchyard/config/Configuration.java
+++ b/config/src/main/java/org/switchyard/config/Configuration.java
@@ -16,7 +16,6 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, 
  * MA  02110-1301, USA.
  */
-
 package org.switchyard.config;
 
 import java.io.IOException;
@@ -28,6 +27,8 @@ import java.util.Set;
 
 import javax.xml.namespace.QName;
 import javax.xml.transform.Source;
+
+import org.switchyard.common.property.PropertyResolver;
 
 /**
  * The central and most important interface of the Configuration API.
@@ -345,6 +346,19 @@ public interface Configuration {
      * @return this config (useful for chaining)
      */
     public Configuration orderChildren(boolean recursive);
+
+    /**
+     * Gets the PropertyResolver.
+     * @return the PropertyResolver
+     */
+    public PropertyResolver getPropertyResolver();
+
+    /**
+     * Sets the PropertyResolver.
+     * @param propertyResolver the PropertyResolver.
+     * @return this config (useful for chaining)
+     */
+    public Configuration setPropertyResolver(PropertyResolver propertyResolver);
 
     /**
      * Copies this config.

--- a/config/src/main/java/org/switchyard/config/model/domain/v1/V1DomainModel.java
+++ b/config/src/main/java/org/switchyard/config/model/domain/v1/V1DomainModel.java
@@ -75,6 +75,10 @@ public class V1DomainModel extends BaseNamedModel implements DomainModel {
     public DomainModel setProperties(PropertiesModel properties) {
         setChildModel(properties);
         _properties = properties;
+        SwitchYardModel switchyard = getSwitchYard();
+        if (switchyard != null) {
+            switchyard.setDomainPropertyResolver();
+        }
         return this;
     }
 

--- a/config/src/main/java/org/switchyard/config/model/property/PropertiesModel.java
+++ b/config/src/main/java/org/switchyard/config/model/property/PropertiesModel.java
@@ -22,12 +22,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
+import org.switchyard.common.property.PropertyResolver;
 import org.switchyard.config.model.Model;
 
 /**
  * The "properties" configuration model.
  */
-public interface PropertiesModel extends Model {
+public interface PropertiesModel extends Model, PropertyResolver {
 
     /** The "properties" name. */
     public static final String PROPERTIES = "properties";

--- a/config/src/main/java/org/switchyard/config/model/property/v1/V1PropertiesModel.java
+++ b/config/src/main/java/org/switchyard/config/model/property/v1/V1PropertiesModel.java
@@ -156,4 +156,13 @@ public class V1PropertiesModel extends BaseModel implements PropertiesModel {
         return map;
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String resolveProperty(String key) {
+        PropertyModel property = getProperty(key);
+        return property != null ? property.getValue() : null;
+    }
+
 }

--- a/config/src/main/java/org/switchyard/config/model/switchyard/SwitchYardModel.java
+++ b/config/src/main/java/org/switchyard/config/model/switchyard/SwitchYardModel.java
@@ -101,6 +101,10 @@ public interface SwitchYardModel extends NamedModel {
      * @return this SwitchyardModel (useful for chaining)
      */
     public SwitchYardModel setDomain(DomainModel domain);
-    
-    
+
+    /**
+     * Sets the domain property resolver based on the curren state of the model.
+     */
+    public void setDomainPropertyResolver();
+
 }

--- a/config/src/main/java/org/switchyard/config/model/switchyard/v1/V1SwitchYardModel.java
+++ b/config/src/main/java/org/switchyard/config/model/switchyard/v1/V1SwitchYardModel.java
@@ -20,11 +20,15 @@ package org.switchyard.config.model.switchyard.v1;
 
 import javax.xml.namespace.QName;
 
+import org.switchyard.common.property.CompoundPropertyResolver;
+import org.switchyard.common.property.PropertyResolver;
+import org.switchyard.common.property.SystemPropertiesPropertyResolver;
 import org.switchyard.config.Configuration;
 import org.switchyard.config.model.BaseNamedModel;
 import org.switchyard.config.model.Descriptor;
 import org.switchyard.config.model.composite.CompositeModel;
 import org.switchyard.config.model.domain.DomainModel;
+import org.switchyard.config.model.property.PropertiesModel;
 import org.switchyard.config.model.switchyard.ArtifactsModel;
 import org.switchyard.config.model.switchyard.SwitchYardModel;
 import org.switchyard.config.model.transform.TransformsModel;
@@ -49,6 +53,7 @@ public class V1SwitchYardModel extends BaseNamedModel implements SwitchYardModel
     public V1SwitchYardModel() {
         super(new QName(SwitchYardModel.DEFAULT_NAMESPACE, SwitchYardModel.SWITCHYARD));
         setModelChildrenOrder(CompositeModel.COMPOSITE, TransformsModel.TRANSFORMS, ValidatesModel.VALIDATES, DomainModel.DOMAIN, ArtifactsModel.ARTIFACTS);
+        setDomainPropertyResolver();
     }
 
     /**
@@ -59,6 +64,7 @@ public class V1SwitchYardModel extends BaseNamedModel implements SwitchYardModel
     public V1SwitchYardModel(Configuration config, Descriptor desc) {
         super(config, desc);
         setModelChildrenOrder(CompositeModel.COMPOSITE, TransformsModel.TRANSFORMS, ValidatesModel.VALIDATES, DomainModel.DOMAIN, ArtifactsModel.ARTIFACTS);
+        setDomainPropertyResolver();
     }
 
     /**
@@ -163,7 +169,23 @@ public class V1SwitchYardModel extends BaseNamedModel implements SwitchYardModel
     public SwitchYardModel setDomain(DomainModel domain) {
         setChildModel(domain);
         _domain = domain;
+        setDomainPropertyResolver();
         return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setDomainPropertyResolver() {
+        DomainModel domain = getDomain();
+        if (domain != null) {
+            PropertiesModel properties = domain.getProperties();
+            if (properties != null) {
+                PropertyResolver pr = new CompoundPropertyResolver(SystemPropertiesPropertyResolver.instance(), properties);
+                getModelConfiguration().setPropertyResolver(pr);
+            }
+        }
     }
 
 }

--- a/config/src/test/java/org/switchyard/config/model/switchyard/SwitchYardModelTests.java
+++ b/config/src/test/java/org/switchyard/config/model/switchyard/SwitchYardModelTests.java
@@ -102,6 +102,7 @@ public class SwitchYardModelTests {
         SOAPBindingModel binding = (SOAPBindingModel)service.getBindings().get(0);
         PortModel port = binding.getPort();
         Assert.assertEquals("MyWebService/SOAPPort", port.getPort());
+        Assert.assertEquals("service.wsdl", binding.getWSDL().getLocation());
         String name = port.getBinding().getService().getComposite().getComponents().get(0).getName();
         Assert.assertEquals("SimpleService", name);
         // Verify transform configuration
@@ -120,9 +121,14 @@ public class SwitchYardModelTests {
         Assert.assertEquals("TestDomain", domain.getName());
         // Verify property configuration
         PropertiesModel props = domain.getProperties();
-        Assert.assertEquals(2, props.getProperties().size());
+        Assert.assertEquals(7, props.getProperties().size());
         Assert.assertEquals("bar", props.getProperty("foo").getValue());
         Assert.assertEquals("fish", props.getProperty("tuna").getValue());
+        Assert.assertEquals(System.getProperty("user.name"), props.getProperty("userName").getValue());
+        Assert.assertEquals(System.getProperty("os.name"), props.getProperty("osName").getValue());
+        Assert.assertEquals("iam", props.getProperty("whoIsWill").getValue());
+        Assert.assertEquals("stuff", props.getProperty("smooksConfig").getValue());
+        Assert.assertEquals("service", props.getProperty("soapWsdlName").getValue());
         Assert.assertEquals(switchyard, domain.getSwitchYard());
         // Verify handler configuration
         Assert.assertEquals(1, domain.getHandlers().getHandlers().size());

--- a/config/src/test/java/org/switchyard/config/util/classpath/ConfigClasspathScanTest.java
+++ b/config/src/test/java/org/switchyard/config/util/classpath/ConfigClasspathScanTest.java
@@ -19,21 +19,17 @@
 
 package org.switchyard.config.util.classpath;
 
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+
 import org.junit.Assert;
 import org.junit.Test;
 import org.switchyard.common.type.classpath.ClasspathScanner;
 import org.switchyard.common.type.classpath.InstanceOfFilter;
-import org.switchyard.common.type.classpath.ResourceExistsFilter;
 import org.switchyard.config.BaseConfiguration;
 import org.switchyard.config.Configuration;
 import org.switchyard.config.DOMConfiguration;
-
-import javax.activation.CommandMap;
-import javax.activation.MailcapCommandMap;
-import java.io.File;
-import java.io.FileWriter;
-import java.io.IOException;
-import java.util.List;
 
 /**
  * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>

--- a/config/src/test/resources/org/switchyard/config/model/switchyard/SwitchYardModelTests-Complete.xml
+++ b/config/src/test/resources/org/switchyard/config/model/switchyard/SwitchYardModelTests-Complete.xml
@@ -38,7 +38,7 @@ MA  02110-1301, USA.
         <sca:service name="M1AppService" promote="SimpleService">
             <soap:binding.soap>
                 <soap:port secure="true">MyWebService/SOAPPort</soap:port>
-                <soap:wsdl description="foobar">service.wsdl</soap:wsdl>
+                <soap:wsdl description="foobar">${soapWsdlName}.wsdl</soap:wsdl>
             </soap:binding.soap>
         </sca:service>
         <sca:component name="SimpleService">
@@ -60,7 +60,7 @@ MA  02110-1301, USA.
     <transforms>
         <java:transform.java from="msgA" to="msgB" class="org.examples.transform.AtoBTransform"/>
         <smooks:transform.smooks from="msgC" to="msgD">
-            <smooks:config>stuff</smooks:config>
+            <smooks:config>${smooksConfig}</smooks:config>
         </smooks:transform.smooks>
     </transforms>
     <validates>
@@ -77,13 +77,18 @@ MA  02110-1301, USA.
         <properties>
             <property name="foo" value="bar"/>
             <property name="tuna" value="fish"/>
+            <property name="userName" value="${user.name}"/>
+            <property name="osName" value="${os.name}"/>
+            <property name="whoIsWill" value="iam"/>
+            <property name="smooksConfig" value="stuff"/>
+            <property name="soapWsdlName" value="service"/>
         </properties>
         <handlers>
             <handler name="handler1" class="org.switchyard.handlers.TestHandler"/>
         </handlers>
         <security callbackHandler="java.lang.Object" moduleName="other">
             <properties>
-                <property name="will" value="iam"/>
+                <property name="will" value="${whoIsWill}"/>
             </properties>
         </security>
     </domain>

--- a/config/src/test/resources/org/switchyard/config/model/switchyard/SwitchYardModelTests-Fragment.xml
+++ b/config/src/test/resources/org/switchyard/config/model/switchyard/SwitchYardModelTests-Fragment.xml
@@ -27,7 +27,7 @@ MA  02110-1301, USA.
         <sca:service name="M1AppService" promote="SimpleService">
             <soap:binding.soap>
                 <soap:port secure="true">MyWebService/SOAPPort</soap:port>
-                <soap:wsdl description="foobar">service.wsdl</soap:wsdl>
+                <soap:wsdl description="foobar">${soapWsdlName}.wsdl</soap:wsdl>
             </soap:binding.soap>
         </sca:service>
     </sca:composite>

--- a/config/src/test/resources/org/switchyard/config/model/switchyard/SwitchYardModelTests-Incomplete.xml
+++ b/config/src/test/resources/org/switchyard/config/model/switchyard/SwitchYardModelTests-Incomplete.xml
@@ -52,7 +52,7 @@ MA  02110-1301, USA.
     <transforms>
         <java:transform.java from="msgA" to="msgB" class="org.examples.transform.AtoBTransform"/>
         <smooks:transform.smooks from="msgC" to="msgD">
-            <smooks:config>stuff</smooks:config>
+            <smooks:config>${smooksConfig}</smooks:config>
         </smooks:transform.smooks>
     </transforms>
     <validates>
@@ -69,13 +69,18 @@ MA  02110-1301, USA.
         <properties>
             <property name="foo" value="bar"/>
             <property name="tuna" value="fish"/>
+            <property name="userName" value="${user.name}"/>
+            <property name="osName" value="${os.name}"/>
+            <property name="whoIsWill" value="iam"/>
+            <property name="smooksConfig" value="stuff"/>
+            <property name="soapWsdlName" value="service"/>
         </properties>
         <handlers>
             <handler name="handler1" class="org.switchyard.handlers.TestHandler"/>
         </handlers>
         <security callbackHandler="java.lang.Object" moduleName="other">
             <properties>
-                <property name="will" value="iam"/>
+                <property name="will" value="${whoIsWill}"/>
             </properties>
         </security>
     </domain>


### PR DESCRIPTION
SWITCHYARD-1268: Add support for system property and domain property replacement across switchyard config
https://issues.jboss.org/browse/SWITCHYARD-1268
