### PR TITLE
SWITCHYARD-1322: change to core pom structure breaks build

### DIFF
--- a/common/camel/pom.xml
+++ b/common/camel/pom.xml
@@ -31,7 +31,7 @@
         <groupId>org.switchyard</groupId>
         <artifactId>switchyard-core-parent</artifactId>
         <version>0.8.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
+        <relativePath>../../pom.xml</relativePath>
     </parent>
     <dependencies>
         <dependency>

--- a/common/cdi/pom.xml
+++ b/common/cdi/pom.xml
@@ -31,7 +31,7 @@
         <groupId>org.switchyard</groupId>
         <artifactId>switchyard-core-parent</artifactId>
         <version>0.8.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
+        <relativePath>../../pom.xml</relativePath>
     </parent>
     <dependencies>
         <!-- external dependencies -->

--- a/common/core/pom.xml
+++ b/common/core/pom.xml
@@ -31,7 +31,7 @@
         <groupId>org.switchyard</groupId>
         <artifactId>switchyard-core-parent</artifactId>
         <version>0.8.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
+        <relativePath>../../pom.xml</relativePath>
     </parent>
     <dependencies>
         <!-- external dependencies -->


### PR DESCRIPTION
SWITCHYARD-1322: change to core pom structure breaks build
https://issues.jboss.org/browse/SWITCHYARD-1322
