### PR TITLE
SWITCHYARD-1366: Update RoundRobinStrategy to support multiple service n...

### DIFF
--- a/remote/src/main/java/org/switchyard/remote/cluster/RoundRobinStrategy.java
+++ b/remote/src/main/java/org/switchyard/remote/cluster/RoundRobinStrategy.java
@@ -19,6 +19,9 @@
 package org.switchyard.remote.cluster;
 
 import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.xml.namespace.QName;
 
@@ -33,7 +36,7 @@ import org.switchyard.remote.RemoteEndpoint;
  */
 public class RoundRobinStrategy extends BaseStrategy {
     
-    private int _endpointIdx;
+    private ConcurrentMap<QName, AtomicInteger> _endpointIdxs = new ConcurrentHashMap<QName, AtomicInteger>();
     
     /**
      * Create a new RoundRobin strategy.
@@ -47,13 +50,15 @@ public class RoundRobinStrategy extends BaseStrategy {
         if (getRegistry() == null) {
             return null;
         }
-        
         RemoteEndpoint selectedEp = null;
         List<RemoteEndpoint> eps = getRegistry().getEndpoints(serviceName);
         if (!eps.isEmpty()) {
-            _endpointIdx %= eps.size();
-            selectedEp = eps.get(_endpointIdx);
-            _endpointIdx++;
+            _endpointIdxs.putIfAbsent(serviceName, new AtomicInteger(0));
+            AtomicInteger idx = _endpointIdxs.get(serviceName);
+            synchronized (idx) {
+                idx.set(idx.get()%eps.size());
+                selectedEp = eps.get(idx.getAndIncrement());
+            }
         }
         
         return selectedEp;

--- a/remote/src/test/java/org/switchyard/remote/cluster/MockRegistry.java
+++ b/remote/src/test/java/org/switchyard/remote/cluster/MockRegistry.java
@@ -19,7 +19,9 @@
 package org.switchyard.remote.cluster;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import javax.xml.namespace.QName;
 
@@ -31,11 +33,18 @@ import org.switchyard.remote.RemoteRegistry;
  */
 public class MockRegistry implements RemoteRegistry {
     
-    private List<RemoteEndpoint> endpoints = new ArrayList<RemoteEndpoint>();
+    private Map<QName, List<RemoteEndpoint>> endpoints = new HashMap<QName, List<RemoteEndpoint>>();
 
     @Override
     public void addEndpoint(RemoteEndpoint endpoint) {
-        endpoints.add(endpoint);
+        List<RemoteEndpoint> eps = endpoints.get(endpoint.getServiceName());
+        if (eps == null) {
+            endpoints.put(endpoint.getServiceName(),
+                    new ArrayList<RemoteEndpoint>());
+            endpoints.get(endpoint.getServiceName()).add(endpoint);
+        } else {
+            endpoints.get(endpoint.getServiceName()).add(endpoint);
+        }
     }
 
     @Override
@@ -45,7 +54,11 @@ public class MockRegistry implements RemoteRegistry {
 
     @Override
     public List<RemoteEndpoint> getEndpoints(QName serviceName) {
-        return endpoints;
+        List<RemoteEndpoint> eps = endpoints.get(serviceName);
+        if (eps == null) {
+            return new ArrayList<RemoteEndpoint>();
+        }
+        return eps;
     }
 
 }

--- a/remote/src/test/java/org/switchyard/remote/cluster/RoundRobinStrategyTest.java
+++ b/remote/src/test/java/org/switchyard/remote/cluster/RoundRobinStrategyTest.java
@@ -29,7 +29,9 @@ import org.switchyard.remote.RemoteRegistry;
 
 public class RoundRobinStrategyTest {
     
-    private static final QName TEST_SERVICE = new QName("RoundRobinStrategy");
+    private static final QName TEST_SERVICE1 = new QName("RoundRobinStrategy1");
+    private static final QName TEST_SERVICE2 = new QName("RoundRobinStrategy2");
+    
     private RemoteRegistry registry = new MockRegistry();
     private RoundRobinStrategy robin = new RoundRobinStrategy();
 
@@ -40,26 +42,32 @@ public class RoundRobinStrategyTest {
     
     @Test
     public void noEndpoints() {
-        Assert.assertNull(robin.selectEndpoint(TEST_SERVICE));
+        Assert.assertNull(robin.selectEndpoint(TEST_SERVICE1));
     }
     
     @Test
     public void oneEndpoint() {
-        registry.addEndpoint(new RemoteEndpoint().setServiceName(TEST_SERVICE));
-        Assert.assertNotNull(robin.selectEndpoint(TEST_SERVICE));
+        registry.addEndpoint(new RemoteEndpoint().setServiceName(TEST_SERVICE1));
+        Assert.assertNotNull(robin.selectEndpoint(TEST_SERVICE1));
     }
     
     @Test
     public void multipleEndpoints() {
-        // register two endpoints for the same service
-        RemoteEndpoint ep1 = new RemoteEndpoint().setServiceName(TEST_SERVICE).setEndpoint("ep1");
-        RemoteEndpoint ep2 = new RemoteEndpoint().setServiceName(TEST_SERVICE).setEndpoint("ep2");
+        // register endpoints for each service
+        RemoteEndpoint ep1 = new RemoteEndpoint().setServiceName(TEST_SERVICE1).setEndpoint("ep1");
+        RemoteEndpoint ep2 = new RemoteEndpoint().setServiceName(TEST_SERVICE1).setEndpoint("ep2");
+        RemoteEndpoint ep3 = new RemoteEndpoint().setServiceName(TEST_SERVICE2).setEndpoint("ep3");
+        RemoteEndpoint ep4 = new RemoteEndpoint().setServiceName(TEST_SERVICE2).setEndpoint("ep4");
         registry.addEndpoint(ep1);
         registry.addEndpoint(ep2);
+        registry.addEndpoint(ep3);
+        registry.addEndpoint(ep4);
         
         // check to see we get round robin behavior
-        Assert.assertEquals(ep1, robin.selectEndpoint(TEST_SERVICE));
-        Assert.assertEquals(ep2, robin.selectEndpoint(TEST_SERVICE));
-        Assert.assertEquals(ep1, robin.selectEndpoint(TEST_SERVICE));
+        Assert.assertEquals(ep1, robin.selectEndpoint(TEST_SERVICE1));
+        Assert.assertEquals(ep3, robin.selectEndpoint(TEST_SERVICE2));
+        Assert.assertEquals(ep2, robin.selectEndpoint(TEST_SERVICE1));
+        Assert.assertEquals(ep4, robin.selectEndpoint(TEST_SERVICE2));
+        Assert.assertEquals(ep1, robin.selectEndpoint(TEST_SERVICE1));
     }
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/SWITCHYARD-1366

RoundRobinStrategy dosen't take into account the multiple service. I modified RoundRobinStrategy, RoundRobinStrategyTest and MockRegistry. You can run JUnit Test using RoundRobinStrategyTest.java.
