### PR TITLE
SWITCHYARD-1435 ExchangeCompletion event missing after Camel refactor

### DIFF
--- a/bus/camel/src/test/java/org/switchyard/bus/camel/ExchangeDispatcherTest.java
+++ b/bus/camel/src/test/java/org/switchyard/bus/camel/ExchangeDispatcherTest.java
@@ -61,6 +61,7 @@ public class ExchangeDispatcherTest {
     public void setUp() throws Exception {
         _domain = new MockDomain();
         _camelContext = new SwitchYardCamelContext();
+        _camelContext.setServiceDomain(_domain);
         _provider = new CamelExchangeBus(_camelContext);
         _provider.init(_domain);
         _camelContext.start();

--- a/common/camel/src/main/java/org/switchyard/common/camel/SwitchYardCamelContext.java
+++ b/common/camel/src/main/java/org/switchyard/common/camel/SwitchYardCamelContext.java
@@ -77,10 +77,10 @@ public class SwitchYardCamelContext extends DefaultCamelContext {
         _cdiIntegration = autoDetectCdi;
         if (isEnableCdiIntegration()) {
             setInjector(new CdiInjector(getInjector()));
-            getManagementStrategy().addEventNotifier(new CamelEventBridge());
         } else {
             _logger.warn("CDI environment not detected, disabling Camel CDI integration");
         }
+        getManagementStrategy().addEventNotifier(new CamelEventBridge());
     }
 
     /**


### PR DESCRIPTION
Proposed solution uses CamelEventBridge which lets use Camel Management API to publish events. More over SwitchYard event observers may receive camel events thanks to this solution.
