### PR TITLE
SWITCHYARD-737 Update BPEL schema referenced by SwitchYard

### DIFF
--- a/config/src/main/java/org/switchyard/config/model/composite/v1/V1CompositeMarshaller.java
+++ b/config/src/main/java/org/switchyard/config/model/composite/v1/V1CompositeMarshaller.java
@@ -23,6 +23,8 @@ import org.switchyard.config.Configuration;
 import org.switchyard.config.model.BaseMarshaller;
 import org.switchyard.config.model.Descriptor;
 import org.switchyard.config.model.Model;
+import org.switchyard.config.model.implementation.bpel.BPELComponentImplementationModel;
+import org.switchyard.config.model.implementation.bpel.v1.V1BPELComponentImplementationModel;
 import org.switchyard.config.model.composite.BindingModel;
 import org.switchyard.config.model.composite.ComponentImplementationModel;
 import org.switchyard.config.model.composite.ComponentModel;
@@ -41,6 +43,8 @@ import org.switchyard.config.model.property.v1.V1PropertyModel;
  */
 public class V1CompositeMarshaller extends BaseMarshaller {
 
+    private static final String IMPLEMENTATION_BPEL= ComponentImplementationModel.IMPLEMENTATION + "." + BPELComponentImplementationModel.BPEL;    
+    
     /**
      * Constructs a new V1CompositeMarshaller with the specified Descriptor.
      * @param desc the Descriptor
@@ -76,6 +80,9 @@ public class V1CompositeMarshaller extends BaseMarshaller {
         } else if (name.equals(ComponentModel.COMPONENT)) {
             return new V1ComponentModel(config, desc);
         } else if (name.startsWith(ComponentImplementationModel.IMPLEMENTATION)) {
+            if (name.equals(IMPLEMENTATION_BPEL)) {
+                return new V1BPELComponentImplementationModel(config, getDescriptor());
+            }
             return new V1ComponentImplementationModel(config, desc);
         } else if (name.startsWith(InterfaceModel.INTERFACE)) {
             Configuration config_parent = config.getParent();

--- a/config/src/main/java/org/switchyard/config/model/implementation/bpel/BPELComponentImplementationModel.java
+++ b/config/src/main/java/org/switchyard/config/model/implementation/bpel/BPELComponentImplementationModel.java
@@ -1,0 +1,63 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+package org.switchyard.config.model.implementation.bpel;
+
+import javax.xml.namespace.QName;
+
+import org.switchyard.config.model.composite.ComponentImplementationModel;
+
+/**
+ * A "bpel" ComponentImplementationModel.
+ *
+ */
+public interface BPELComponentImplementationModel extends ComponentImplementationModel {
+
+    /**
+     * The "bpel" namespace.
+     */
+    public static final String DEFAULT_NAMESPACE = "http://docs.oasis-open.org/ns/opencsa/sca/200912";
+
+    /**
+     * The "bpel" implementation type.
+     */
+    public static final String BPEL = "bpel";
+    
+    /**
+     * Gets the "process" attribute.
+     *
+     * @return the "process" attribute
+     */
+    public String getProcess();
+
+    /**
+     * Gets the "process" attribute as a QName.
+     *
+     * @return the "process" attribute
+     */
+    public QName getProcessQName();
+
+    /**
+     * Sets the "process" attribute.
+     *
+     * @param process the "process" attribute
+     * @return this instance (useful for chaining)
+     */
+    public BPELComponentImplementationModel setProcess(String process);
+
+}

--- a/config/src/main/java/org/switchyard/config/model/implementation/bpel/ProcessConstants.java
+++ b/config/src/main/java/org/switchyard/config/model/implementation/bpel/ProcessConstants.java
@@ -1,0 +1,43 @@
+/* 
+ * JBoss, Home of Professional Open Source 
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved. 
+ * See the copyright.txt in the distribution for a 
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use, 
+ * modify, copy, or redistribute it subject to the terms and conditions 
+ * of the GNU Lesser General Public License, v. 2.1. 
+ * This program is distributed in the hope that it will be useful, but WITHOUT A 
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details. 
+ * You should have received a copy of the GNU Lesser General Public License, 
+ * v.2.1 along with this distribution; if not, write to the Free Software 
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, 
+ * MA  02110-1301, USA.
+ */
+package org.switchyard.config.model.implementation.bpel;
+
+import javax.xml.namespace.QName;
+
+/**
+ * Various constants and context variables.
+ *
+ */
+public final class ProcessConstants {
+
+    private ProcessConstants() {
+    }
+    
+    /**
+     * The default process namespace.
+     */
+    public static final String PROCESS_NAMESPACE = "http://docs.oasis-open.org/ns/opencsa/sca/200912";
+
+    /** processDescriptor . */
+    public static final String PROCESS = "process";
+    
+    /** {http://docs.oasis-open.org/ns/opencsa/sca/200912}process . */
+    public static final String PROCESS_VAR = new QName(PROCESS_NAMESPACE, PROCESS).toString();
+
+}

--- a/config/src/main/java/org/switchyard/config/model/implementation/bpel/v1/V1BPELComponentImplementationModel.java
+++ b/config/src/main/java/org/switchyard/config/model/implementation/bpel/v1/V1BPELComponentImplementationModel.java
@@ -1,0 +1,75 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+package org.switchyard.config.model.implementation.bpel.v1;
+
+import static org.switchyard.config.model.implementation.bpel.ProcessConstants.PROCESS;
+
+import javax.xml.namespace.QName;
+
+import org.switchyard.config.model.implementation.bpel.BPELComponentImplementationModel;
+import org.switchyard.config.Configuration;
+import org.switchyard.config.model.Descriptor;
+import org.switchyard.config.model.composite.v1.V1ComponentImplementationModel;
+
+/**
+ * A "bpel" implementation of a ComponentImplementationModel.
+ *
+ */
+public class V1BPELComponentImplementationModel extends V1ComponentImplementationModel implements BPELComponentImplementationModel {
+
+    /**
+     * Default constructor for application use.
+     */
+    public V1BPELComponentImplementationModel() {
+        super(BPEL, DEFAULT_NAMESPACE);
+    }
+
+    /**
+     * Constructor for Marshaller use (ie: V1BPELMarshaller).
+     *
+     * @param config the Configuration
+     * @param desc the Descriptor
+     */
+    public V1BPELComponentImplementationModel(Configuration config, Descriptor desc) {
+        super(config, desc);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public String getProcess() {
+        return getModelAttribute(PROCESS);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public QName getProcessQName() {
+        return getModelConfiguration().getAttributeAsQName(PROCESS);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public BPELComponentImplementationModel setProcess(String process) {
+        setModelAttribute(PROCESS, process);
+        return this;
+    }
+    
+}


### PR DESCRIPTION
Update BPEL schema referenced by SwitchYard.     Add BPEL logic to the composite marshaller.     Move the ComponentImplementationModel to core.
