### PR TITLE
SWITCHYARD-1402 Remove CamelMessageComposer from implementation.camel.

### DIFF
--- a/bus/camel/src/main/java/org/switchyard/bus/camel/CamelMessage.java
+++ b/bus/camel/src/main/java/org/switchyard/bus/camel/CamelMessage.java
@@ -28,11 +28,13 @@ import javax.xml.namespace.QName;
 
 import org.apache.camel.CamelContext;
 import org.apache.camel.Exchange;
-import org.apache.camel.impl.DefaultMessage;
 import org.switchyard.Context;
 import org.switchyard.Message;
+import org.switchyard.common.camel.HandlerDataSource;
 import org.switchyard.common.camel.SwitchYardCamelContext;
+import org.switchyard.common.camel.SwitchYardMessage;
 import org.switchyard.exception.SwitchYardException;
+import org.switchyard.label.BehaviorLabel;
 import org.switchyard.metadata.java.JavaService;
 import org.switchyard.transform.Transformer;
 import org.switchyard.transform.TransformerRegistry;
@@ -41,7 +43,7 @@ import org.switchyard.transform.TransformerRegistry;
  * Message implementation which adapt SwitchYard {@link Message} interface to 
  * {@link org.apache.camel.Message}.
  */
-public class CamelMessage extends DefaultMessage implements Message {
+public class CamelMessage extends SwitchYardMessage implements Message {
 
     /**
      * Creates new Camel message with specified exchange.
@@ -143,11 +145,6 @@ public class CamelMessage extends DefaultMessage implements Message {
     }
 
     @Override
-    protected Map<String, Object> createHeaders() {
-        return new HashMap<String, Object>();
-    }
-
-    @Override
     public CamelMessage copy() {
         CamelMessage message = newInstance();
         message.setBody(getBody());
@@ -163,7 +160,7 @@ public class CamelMessage extends DefaultMessage implements Message {
      * Mark message as sent.
      */
     public void sent() {
-        setHeader(CamelExchange.MESSAGE_SENT, true);
+        getContext().setProperty(CamelExchange.MESSAGE_SENT, true).addLabels(BehaviorLabel.TRANSIENT.name());
     }
 
     /**

--- a/common/camel/src/main/java/org/switchyard/common/camel/ContextPropertyUtil.java
+++ b/common/camel/src/main/java/org/switchyard/common/camel/ContextPropertyUtil.java
@@ -1,0 +1,43 @@
+/* 
+ * JBoss, Home of Professional Open Source 
+ * Copyright 2013 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved. 
+ * See the copyright.txt in the distribution for a 
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use, 
+ * modify, copy, or redistribute it subject to the terms and conditions 
+ * of the GNU Lesser General Public License, v. 2.1. 
+ * This program is distributed in the hope that it will be useful, but WITHOUT A 
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details. 
+ * You should have received a copy of the GNU Lesser General Public License, 
+ * v.2.1 along with this distribution; if not, write to the Free Software 
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, 
+ * MA  02110-1301, USA.
+ */
+package org.switchyard.common.camel;
+
+import org.switchyard.Scope;
+
+/**
+ * Utility class for filtering system reserved properties from exchange and message headers.
+ */
+public final class ContextPropertyUtil {
+
+    private ContextPropertyUtil() {
+        
+    }
+
+    /**
+     * Utility method to verify if given property name is reserved for internal
+     * usage.
+     * 
+     * @param propertyName Name of camel exchange property or header.
+     * @param scope Scope of the property.
+     * @return True if property is used internally.
+     */
+    public static boolean isReservedProperty(String propertyName, Scope scope) {
+        return propertyName.startsWith("org.switchyard.bus.camel");
+    }
+}

--- a/common/camel/src/main/java/org/switchyard/common/camel/HandlerDataSource.java
+++ b/common/camel/src/main/java/org/switchyard/common/camel/HandlerDataSource.java
@@ -16,7 +16,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, 
  * MA  02110-1301, USA.
  */
-package org.switchyard.bus.camel;
+package org.switchyard.common.camel;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/common/camel/src/main/java/org/switchyard/common/camel/SwitchYardMessage.java
+++ b/common/camel/src/main/java/org/switchyard/common/camel/SwitchYardMessage.java
@@ -1,0 +1,42 @@
+/* 
+ * JBoss, Home of Professional Open Source 
+ * Copyright 2013 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved. 
+ * See the copyright.txt in the distribution for a 
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use, 
+ * modify, copy, or redistribute it subject to the terms and conditions 
+ * of the GNU Lesser General Public License, v. 2.1. 
+ * This program is distributed in the hope that it will be useful, but WITHOUT A 
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details. 
+ * You should have received a copy of the GNU Lesser General Public License, 
+ * v.2.1 along with this distribution; if not, write to the Free Software 
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, 
+ * MA  02110-1301, USA.
+ */
+package org.switchyard.common.camel;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.camel.impl.DefaultMessage;
+
+/**
+ * An extension of camel default message implementation which uses traditional
+ * case sensitive hash map for storing headers.
+ */
+public class SwitchYardMessage extends DefaultMessage {
+
+    @Override
+    protected Map<String, Object> createHeaders() {
+        return new HashMap<String, Object>();
+    }
+
+    @Override
+    public DefaultMessage newInstance() {
+        return new SwitchYardMessage();
+    }
+
+}


### PR DESCRIPTION
This commit contains shared code which should be placed in core and it's being used by camel exchange bus.
