### PR TITLE
SWITCHYARD-1508 Allow SwitchYardRunner to disable validation of config model xml under test

### DIFF
--- a/test/src/main/java/org/switchyard/test/SwitchYardTestCaseConfig.java
+++ b/test/src/main/java/org/switchyard/test/SwitchYardTestCaseConfig.java
@@ -54,6 +54,11 @@ public @interface SwitchYardTestCaseConfig {
     String config() default NULL_CONFIG;
 
     /**
+     * Whether validating SwitchYard configuration model or not.
+     */
+    boolean validate() default true;
+
+    /**
      * {@link Scanner Scanners} to be used in the test.
      * <p/>
      * These are the same application scanners used by the SwitchYard maven plugin.  The

--- a/test/src/main/java/org/switchyard/test/SwitchYardTestKit.java
+++ b/test/src/main/java/org/switchyard/test/SwitchYardTestKit.java
@@ -144,7 +144,7 @@ public class SwitchYardTestKit {
                 }
 
                 try {
-                    _configModel = createSwitchYardModel(is, createScanners(testCaseConfig));
+                    _configModel = createSwitchYardModel(is, createScanners(testCaseConfig), testCaseConfig.validate());
                 } finally {
                     try {
                         is.close();
@@ -896,7 +896,7 @@ public class SwitchYardTestKit {
         }
     }
 
-    private SwitchYardModel createSwitchYardModel(InputStream configModel, List<Scanner<V1SwitchYardModel>> scanners) {
+    private SwitchYardModel createSwitchYardModel(InputStream configModel, List<Scanner<V1SwitchYardModel>> scanners, boolean validate) {
         Assert.assertNotNull("Test 'configModel' is null.", configModel);
 
         final SwitchYardModel returnModel;
@@ -915,7 +915,9 @@ public class SwitchYardTestKit {
             } else {
                 returnModel = model;
             }
-            returnModel.assertModelValid();
+            if (validate) {
+                returnModel.assertModelValid();
+            }
             return returnModel;
         } catch (java.io.IOException ioEx) {
             throw new SwitchYardException("Failed to read switchyard config.", ioEx);


### PR DESCRIPTION
Introduced 'validate' element to @SwitchYardTestCaseConfig annotation and modified SwitchYardTestKit.createSwitchYardModel(...) method to handle this flag.
https://issues.jboss.org/browse/SWITCHYARD-1508
