### PR TITLE
[SWITCHYARD-1489] - Add support for multi-step transformations in Switch...

### DIFF
--- a/api/src/main/java/org/switchyard/transform/TransformResolver.java
+++ b/api/src/main/java/org/switchyard/transform/TransformResolver.java
@@ -1,0 +1,17 @@
+package org.switchyard.transform;
+
+import javax.xml.namespace.QName;
+
+/**
+ * Transform resolver operations for the Transformer Registry.
+ */
+public interface TransformResolver {
+    
+    /**
+     * Resolve a transform sequence wiring transformers.
+     * @param from from
+     * @param to to
+     * @return transformer
+     */
+    TransformSequence resolveSequence(QName from, QName to);
+}

--- a/api/src/main/java/org/switchyard/transform/TransformerRegistry.java
+++ b/api/src/main/java/org/switchyard/transform/TransformerRegistry.java
@@ -19,6 +19,7 @@
 
 package org.switchyard.transform;
 
+import java.util.List;
 import javax.xml.namespace.QName;
 
 /**
@@ -64,4 +65,26 @@ public interface TransformerRegistry {
      * @return transformer
      */
     Transformer<?, ?> getTransformer(QName from, QName to);
+    
+    /**
+     * Get a list of currently registered Transformers.
+     * @return ArrayList<Transformer<?,?>> list of currently registered transformers.
+     */
+    List<Transformer<?,?>> getRegisteredTransformers();
+    
+    /**
+     * Get a transform sequence wiring transformers.
+     * @param from from
+     * @param to to
+     * @return transformer
+     */
+    TransformSequence getTransformSequence(QName from, QName to);
+    
+    /**
+     * Set an instance of a TransformResolver.
+     * @param resolver resolver
+     * @return 
+     */    
+    void setTransfomResolver(TransformResolver resolver);
+
 }

--- a/runtime/src/main/java/org/switchyard/handlers/TransformHandler.java
+++ b/runtime/src/main/java/org/switchyard/handlers/TransformHandler.java
@@ -91,6 +91,11 @@ public class TransformHandler extends BaseHandler {
         }
         
         // Apply transforms to the message...
+        TransformSequence transformSequence = _registry.getTransformSequence(TransformSequence.getCurrentMessageType(exchange), TransformSequence.getTargetMessageType(exchange));
+        if (transformSequence != null) {
+            transformSequence.associateWith(exchange.getMessage());
+        }    
+        
         TransformSequence.applySequence(exchange, _registry);
         if (!TransformSequence.assertTransformsApplied(exchange)) {
             QName actualPayloadType = TransformSequence.getCurrentMessageType(exchange);

--- a/runtime/src/main/java/org/switchyard/internal/transform/BaseTransformResolver.java
+++ b/runtime/src/main/java/org/switchyard/internal/transform/BaseTransformResolver.java
@@ -1,0 +1,86 @@
+package org.switchyard.internal.transform;
+
+import java.util.ArrayList;
+
+import javax.xml.namespace.QName;
+
+import org.switchyard.transform.TransformResolver;
+import org.switchyard.transform.TransformSequence;
+import org.switchyard.transform.Transformer;
+import org.switchyard.transform.TransformerRegistry;
+
+/**
+ * Base implementation of the TransformResolver strategy that facilitates resolving of 
+ * direct/indirect transform sequences.
+ */
+public class BaseTransformResolver implements TransformResolver {
+    private TransformerRegistry _registry;
+
+    /**
+     * Create a new TransformResolver instance.
+     */    
+    public BaseTransformResolver() {
+        super();
+    }
+
+
+    /**
+     * Create a new TransformResolver instance and associate it with a TransformRegistry.
+     * @param registry set of transformers to add to registry
+     */
+    public BaseTransformResolver(TransformerRegistry registry) {
+        super();
+        this._registry = registry;
+    }
+
+
+    @Override
+    public TransformSequence resolveSequence(QName from, QName to) {
+        ArrayList<Transformer<?,?>> fromMatches = new ArrayList<Transformer<?,?>>();
+        ArrayList<Transformer<?,?>> toMatches = new ArrayList<Transformer<?,?>>();
+        TransformSequence transformSequence = null;
+        
+        for (Transformer<?,?> entry : _registry.getRegisteredTransformers()) {
+            if ((entry.getFrom().equals(from)) && (entry.getTo().equals(to))) {
+                transformSequence = TransformSequence.from(entry.getFrom()).to(entry.getTo());
+                break;
+            } else if (entry.getFrom().equals(from)) {
+                fromMatches.add(entry);
+            } else if (entry.getTo().equals(to)) {
+                toMatches.add(entry);
+            }            
+        }
+
+        if (transformSequence == null) {
+            // match 1st occurence of the first level of indirection (A->B,B->C instead of A->C)
+            for (Transformer<?,?> fromTransformer : fromMatches) {
+                for (Transformer<?,?> toTransformer : toMatches) {
+                    if (fromTransformer.getTo().equals(toTransformer.getFrom())) {
+                        transformSequence = TransformSequence.from(fromTransformer.getFrom()).to(fromTransformer.getTo()).to(to);
+                        break;
+                    }
+                }
+            }
+        }
+        
+        return transformSequence;
+    }
+
+    /**
+     * Get the associated TransformerRegistry.
+     * @return TransformerRegistry.
+     */
+    public TransformerRegistry getRegistry() {
+        return _registry;
+    }
+
+    /**
+     * Sets the TransformerRegistry instance.
+     * @param registry transformer registry
+     */
+    public void setRegistry(TransformerRegistry registry) {
+        this._registry = registry;
+    }
+
+    
+}

--- a/runtime/src/main/java/org/switchyard/internal/transform/BaseTransformerRegistry.java
+++ b/runtime/src/main/java/org/switchyard/internal/transform/BaseTransformerRegistry.java
@@ -36,6 +36,8 @@ import org.switchyard.common.xml.QNameUtil;
 import org.switchyard.event.EventPublisher;
 import org.switchyard.event.TransformerAddedEvent;
 import org.switchyard.event.TransformerRemovedEvent;
+import org.switchyard.transform.TransformResolver;
+import org.switchyard.transform.TransformSequence;
 import org.switchyard.transform.Transformer;
 import org.switchyard.transform.TransformerRegistry;
 
@@ -58,6 +60,7 @@ public class BaseTransformerRegistry implements TransformerRegistry {
         new ConcurrentHashMap<NameKey, Transformer<?,?>>();
 
     private EventPublisher _eventPublisher;
+    private TransformResolver _transformResolver = new BaseTransformResolver(this);
 
     /**
      * Constructor.
@@ -121,6 +124,11 @@ public class BaseTransformerRegistry implements TransformerRegistry {
         }
 
         return transformer;
+    }
+
+    @Override
+    public TransformSequence getTransformSequence(QName from, QName to) {        
+        return _transformResolver.resolveSequence(from, to);
     }
 
     @Override
@@ -198,6 +206,16 @@ public class BaseTransformerRegistry implements TransformerRegistry {
         return removed;
     }
     
+    @Override
+    public List<Transformer<?, ?>> getRegisteredTransformers() {
+        return new ArrayList<Transformer<?, ?>>(_transformers.values());
+    }
+
+    @Override
+    public void setTransfomResolver(TransformResolver resolver) {
+        this._transformResolver = resolver;        
+    }
+
     // Convenience method to guard against cases when an event publisher has 
     // not been set.
     private void publishEvent(EventObject event) {

--- a/runtime/src/test/java/org/switchyard/internal/transform/BaseTransformerRegistryTest.java
+++ b/runtime/src/test/java/org/switchyard/internal/transform/BaseTransformerRegistryTest.java
@@ -25,8 +25,10 @@ import junit.framework.Assert;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.switchyard.internal.DefaultMessage;
 import org.switchyard.metadata.java.JavaService;
 import org.switchyard.transform.BaseTransformer;
+import org.switchyard.transform.TransformSequence;
 import org.switchyard.transform.Transformer;
 import org.switchyard.transform.TransformerRegistry;
 
@@ -100,6 +102,22 @@ public class BaseTransformerRegistryTest {
 
         transformer = _registry.getTransformer(getType(D.class), new QName("target1"));
     }
+ 
+    @Test
+    public void testGetTransformSequence() {
+        final QName A = new QName("a");
+        final QName B = new QName("b");
+        final QName C = new QName("c");
+        
+        BaseTransformerRegistry _registry = new BaseTransformerRegistry();
+        _registry.addTransformer(new TestTransformer2(A, B));
+        _registry.addTransformer(new TestTransformer2(B, C));
+        
+        TransformSequence transformSequence = _registry.getTransformSequence(A, C);
+        DefaultMessage message = new DefaultMessage().setContent(A);
+        transformSequence.apply(message, _registry);
+        Assert.assertEquals(C, message.getContent());      
+    }
 
     private void addTransformer(Class<?> type) {
         QName fromType = getType(type);
@@ -126,6 +144,24 @@ public class BaseTransformerRegistryTest {
         @Override
         public Object transform(Object from) {
             return from;
+        }
+    }
+    
+    private class TestTransformer2 extends BaseTransformer {
+
+        private QName from;
+        private QName to;
+
+        private TestTransformer2(QName from, QName to) {
+            super(from, to);
+            this.from = from;
+            this.to = to;
+        }
+
+        @Override
+        public Object transform(Object from) {
+            Assert.assertEquals(this.from, from);
+            return to;
         }
     }
 }

--- a/runtime/src/test/java/org/switchyard/tests/IndirectTransformationTest.java
+++ b/runtime/src/test/java/org/switchyard/tests/IndirectTransformationTest.java
@@ -1,0 +1,133 @@
+/* 
+ * JBoss, Home of Professional Open Source 
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved. 
+ * See the copyright.txt in the distribution for a 
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use, 
+ * modify, copy, or redistribute it subject to the terms and conditions 
+ * of the GNU Lesser General Public License, v. 2.1. 
+ * This program is distributed in the hope that it will be useful, but WITHOUT A 
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details. 
+ * You should have received a copy of the GNU Lesser General Public License, 
+ * v.2.1 along with this distribution; if not, write to the Free Software 
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, 
+ * MA  02110-1301, USA.
+ */
+
+package org.switchyard.tests;
+
+import javax.xml.namespace.QName;
+
+import junit.framework.Assert;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.switchyard.Exchange;
+import org.switchyard.HandlerException;
+import org.switchyard.Message;
+import org.switchyard.MockDomain;
+import org.switchyard.MockHandler;
+import org.switchyard.ServiceReference;
+import org.switchyard.handlers.TransformHandler;
+import org.switchyard.transform.BaseTransformer;
+import org.switchyard.transform.TransformSequence;
+import org.switchyard.transform.Transformer;
+
+/**
+ * Tests for exercising the TransformationHandler during message exchange.
+ */
+public class IndirectTransformationTest {
+    
+    private MockDomain _domain;
+
+    @Before
+    public void setUp() throws Exception {
+        _domain = new MockDomain();
+    }
+
+    /* Tests to Add :
+     * - test one level deep transformation
+     */
+
+    /**
+     * Test that the secondary Transform that is one level deep (i.e. A->B, B-C) is applied if the primary Transform (A->C) is not available
+     */
+    @Test
+    public void testOneLevelDeepTransformInProvider() throws Exception {
+        final QName serviceName = new QName("nameTransform");
+        final QName inType = new QName("fromA");
+        final QName indirectDestOutType = new QName("viaB");
+        final QName indirectDestInType = new  QName("viaB");
+        final QName finalDestOutType = new  QName("toC");
+        
+        final String input = "Hello";
+        
+        // Add transforms to registry
+        Transformer<String, String> transformAtoB = 
+                new BaseTransformer<String, String>(inType, indirectDestOutType) {
+            public String transform(String from) {
+                // transform the input date to the desired output string
+                return from + " there,";
+            }
+        };
+        _domain.getTransformerRegistry().addTransformer(transformAtoB);
+        
+        Transformer<String, String> transformBtoC = 
+                new BaseTransformer<String, String>(indirectDestInType, finalDestOutType) {
+            public String transform(String from) {
+                // transform the input date to the desired output string
+                return from + " SwitchYard";
+            }
+        };
+        _domain.getTransformerRegistry().addTransformer(transformBtoC);
+        
+        try {
+            // Provide the service
+            TestTransformHandler serviceHandler = new TestTransformHandler();
+            ServiceReference service = _domain.createInOnlyService(serviceName, serviceHandler);
+        
+            // Create the exchange and invoke the service
+            MockHandler invokerHandler = new MockHandler();
+            Exchange exchange = service.createExchange(invokerHandler);
+        
+            // Set the from and to message names.  NOTE: setting to the to message
+            // name will not be necessary once the service definition is available
+            // at runtime
+            Message msg = exchange.createMessage().setContent(input);
+            TransformSequence.
+                    from(inType).
+                    to(finalDestOutType).
+                    associateWith(msg);
+        
+            msg.setContent(input);
+            
+            exchange.send(msg);
+
+            Assert.assertTrue(serviceHandler.isSuccess());
+        } finally {
+            // Must remove this transformer, otherwise it's there for the following test... will be
+            // fixed once we get rid of the static service domain.
+            _domain.getTransformerRegistry().removeTransformer(transformAtoB);
+            _domain.getTransformerRegistry().removeTransformer(transformBtoC);
+        }        
+    }
+    
+    private class TestTransformHandler extends TransformHandler {
+        boolean success = false;
+        
+        public boolean isSuccess() {
+            return success;
+        }
+        
+        @Override
+        public void handleMessage(Exchange exchange) throws HandlerException {
+            String content = (String) exchange.getMessage().getContent();
+            if (content.equals("Hello there, SwitchYard")) {
+                success=true;
+            }
+        }
+    }
+}


### PR DESCRIPTION
...yard

Added support for One level deep transformations (A->B, B->C) when a direct (A->C) transform is absent and an indirect transform is available.

Added unit tests to prove the behavior and successfully cleared checkstyle checks.
