### PR TITLE
SWITCHYARD-1291 Catch component service/reference bindings in deployer

### DIFF
--- a/deploy/base/src/main/java/org/switchyard/deploy/internal/Deployment.java
+++ b/deploy/base/src/main/java/org/switchyard/deploy/internal/Deployment.java
@@ -35,6 +35,7 @@ import org.apache.log4j.Logger;
 import org.switchyard.Service;
 import org.switchyard.ServiceReference;
 import org.switchyard.common.type.Classes;
+import org.switchyard.config.model.Model;
 import org.switchyard.config.model.ModelPuller;
 import org.switchyard.config.model.composite.BindingModel;
 import org.switchyard.config.model.composite.ComponentImplementationModel;
@@ -413,7 +414,16 @@ public class Deployment extends AbstractDeployment {
             for (ComponentReferenceModel reference : component.getReferences()) {
                 _log.debug("Registering reference " + reference.getQName()
                        + " for component " + component.getImplementation().getType() + " for deployment " + getName());
-
+            
+                // Component Reference bindings not allowed, check to see if we find one and throw an exception
+                List<Model> models = reference.getModelChildren();
+                for (Model model : models) {
+                    if (BindingModel.class.isAssignableFrom(model.getClass())) {
+                        throw new SwitchYardException("Component Reference bindings are not allowed.   Found " + model.toString()
+                                + " on reference " + reference.toString());
+                    }
+                }
+                
                 List<Policy> requires = null;
                 try {
                     requires = getPolicyRequirements(reference);
@@ -448,6 +458,17 @@ public class Deployment extends AbstractDeployment {
                 _log.debug("Registering service " + service.getQName()
                        + " for component " + component.getImplementation().getType() + " for deployment " + getName());
 
+                
+                // Component Service bindings not allowed, check to see if we find one and throw an exception
+                List<Model> models = service.getModelChildren();
+                for (Model model : models) {
+                    if (BindingModel.class.isAssignableFrom(model.getClass())) {
+                        throw new SwitchYardException("Component Service bindings are not allowed.   Found " + model.toString()
+                                + " on Service " + service.toString());
+                    }
+                }
+                
+                
                 List<Policy> requires = null;
                 try {
                     requires = getPolicyRequirements(service);

--- a/deploy/base/src/test/java/org/switchyard/deploy/internal/DeploymentTest.java
+++ b/deploy/base/src/test/java/org/switchyard/deploy/internal/DeploymentTest.java
@@ -67,6 +67,48 @@ public class DeploymentTest {
     }
     
     @Test
+    public void testComponentReferenceBinding() throws Exception {
+        InputStream swConfigStream = Classes.getResourceAsStream("/switchyard-config-component-reference-binding-01.xml", getClass());
+        Deployment deployment = new Deployment(swConfigStream);
+        swConfigStream.close();
+
+        MockDomain serviceDomain = new MockDomain();
+        deployment.init(serviceDomain, ActivatorLoader.createActivators(serviceDomain));
+        
+        boolean result = false;
+        try {
+            deployment.start();
+        } catch (SwitchYardException sye) {
+            Assert.assertTrue(sye.getMessage().contains("Component Reference bindings are not allowed.   Found "));
+            result = true;
+        } catch (Exception e) {
+            Assert.fail("Expected to catch a SwitchYardException on deploy.");
+        }
+        Assert.assertTrue("Expected to catch a SwitchYardException on deploy.", result);
+    }
+
+    @Test
+    public void testComponentServiceBinding() throws Exception {
+        InputStream swConfigStream = Classes.getResourceAsStream("/switchyard-config-component-service-binding-01.xml", getClass());
+        Deployment deployment = new Deployment(swConfigStream);
+        swConfigStream.close();
+
+        MockDomain serviceDomain = new MockDomain();
+        deployment.init(serviceDomain, ActivatorLoader.createActivators(serviceDomain));
+        boolean result = false;
+        try {
+            deployment.start();
+        } catch (SwitchYardException sye) { 
+            Assert.assertTrue(sye.getMessage().contains("Component Service bindings are not allowed.   Found"));
+            result = true;
+        } catch (Exception e) {
+            Assert.fail("Expected to catch a SwitchYardException on deploy.");
+        }
+        Assert.assertTrue("Expected to catch a SwitchYardException on deploy.", result);
+    }
+
+    
+    @Test
     public void testRegistrants() throws Exception {
         InputStream swConfigStream = Classes.getResourceAsStream("/switchyard-config-mock-01.xml", getClass());
         Deployment deployment = new Deployment(swConfigStream);

--- a/deploy/base/src/test/resources/switchyard-config-component-reference-binding-01.xml
+++ b/deploy/base/src/test/resources/switchyard-config-component-reference-binding-01.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+JBoss, Home of Professional Open Source
+Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+as indicated by the @authors tag. All rights reserved.
+See the copyright.txt in the distribution for a
+full listing of individual contributors.
+
+This copyrighted material is made available to anyone wishing to use,
+modify, copy, or redistribute it subject to the terms and conditions
+of the GNU Lesser General Public License, v. 2.1.
+This program is distributed in the hope that it will be useful, but WITHOUT A
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+You should have received a copy of the GNU Lesser General Public License,
+v.2.1 along with this distribution; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+MA  02110-1301, USA.
+-->
+<switchyard xmlns="urn:switchyard-config:switchyard:1.0"
+            xmlns:sca="http://docs.oasis-open.org/ns/opencsa/sca/200912"
+            xmlns:mock="urn:switchyard-component-mock:config:1.0"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="urn:switchyard-component-mock:config:1.0 org/switchyard/component/mock/config/model/v1/mock-v1.xsd">
+    <sca:composite name="mockBinding" targetNamespace="urn:test:config-mock-binding:1.0">
+        <sca:service name="TestService" promote="TestService">
+            <mock:binding.no_activator/>
+        </sca:service>
+        <sca:component name="TestService">
+            <mock:implementation.mock/>
+            <sca:service name="TestService">
+                <mock:interface.mock/>
+            </sca:service>
+	    <sca:reference name="TestReference">
+		<sca:binding.sca/>
+ 	    </sca:reference>
+        </sca:component>
+    </sca:composite>
+</switchyard>

--- a/deploy/base/src/test/resources/switchyard-config-component-service-binding-01.xml
+++ b/deploy/base/src/test/resources/switchyard-config-component-service-binding-01.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+JBoss, Home of Professional Open Source
+Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+as indicated by the @authors tag. All rights reserved.
+See the copyright.txt in the distribution for a
+full listing of individual contributors.
+
+This copyrighted material is made available to anyone wishing to use,
+modify, copy, or redistribute it subject to the terms and conditions
+of the GNU Lesser General Public License, v. 2.1.
+This program is distributed in the hope that it will be useful, but WITHOUT A
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+You should have received a copy of the GNU Lesser General Public License,
+v.2.1 along with this distribution; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+MA  02110-1301, USA.
+-->
+<switchyard xmlns="urn:switchyard-config:switchyard:1.0"
+            xmlns:sca="http://docs.oasis-open.org/ns/opencsa/sca/200912"
+            xmlns:mock="urn:switchyard-component-mock:config:1.0"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="urn:switchyard-component-mock:config:1.0 org/switchyard/component/mock/config/model/v1/mock-v1.xsd">
+    <sca:composite name="mockBinding" targetNamespace="urn:test:config-mock-binding:1.0">
+        <sca:service name="TestService" promote="TestService">
+            <mock:binding.no_activator/>
+        </sca:service>
+        <sca:component name="TestService">
+            <mock:implementation.mock/>
+            <sca:service name="TestService">
+                <mock:interface.mock/>
+		<sca:binding.sca/>
+            </sca:service>
+        </sca:component>
+    </sca:composite>
+</switchyard>


### PR DESCRIPTION
Throw an error if we see bindings in component services or component references.     Pull request has been changed to change  SCABindingModel to check whether the model is assignable from BindingModel.
