### PR TITLE
SWITCHYARD-1544: Using the same promoted reference for two components causes issues in the model parser

### DIFF
--- a/config/src/main/java/org/switchyard/config/model/composite/CompositeReferenceModel.java
+++ b/config/src/main/java/org/switchyard/config/model/composite/CompositeReferenceModel.java
@@ -42,16 +42,10 @@ public interface CompositeReferenceModel extends NamedModel {
     public CompositeModel getComposite();
 
     /**
-     * Gets the child component model.
-     * @return the child component model
+     * Gets the child component reference models.
+     * @return the child component reference models
      */
-    public ComponentModel getComponent();
-
-    /**
-     * Gets the child component reference model.
-     * @return the child component reference model
-     */
-    public ComponentReferenceModel getComponentReference();
+    public List<ComponentReferenceModel> getComponentReferences();
 
     /**
      * Gets the promote attribute.

--- a/config/src/main/java/org/switchyard/config/model/composite/CompositeServiceModel.java
+++ b/config/src/main/java/org/switchyard/config/model/composite/CompositeServiceModel.java
@@ -37,12 +37,6 @@ public interface CompositeServiceModel extends NamedModel {
     public CompositeModel getComposite();
 
     /**
-     * Gets the child component model.
-     * @return the child component model
-     */
-    public ComponentModel getComponent();
-
-    /**
      * Gets the child component service model.
      * @return the child component service model
      */

--- a/config/src/test/resources/org/switchyard/config/model/composite/CompositeModelTests-Promote.xml
+++ b/config/src/test/resources/org/switchyard/config/model/composite/CompositeModelTests-Promote.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ - Copyright 2013 Red Hat Inc. and/or its affiliates and other contributors.
+ - 
+ - Licensed under the Apache License, Version 2.0 (the "License");
+ - you may not use this file except in compliance with the License.
+ - You may obtain a copy of the License at
+ - http://www.apache.org/licenses/LICENSE-2.0
+ - Unless required by applicable law or agreed to in writing, software
+ - distributed under the License is distributed on an "AS IS" BASIS,
+ - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ - See the License for the specific language governing permissions and
+ - limitations under the License.
+ -->
+<sca:composite xmlns:sca="http://docs.oasis-open.org/ns/opencsa/sca/200912"
+        targetNamespace="urn:m1app:example:1.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns:bean="urn:switchyard-config:test-bean:1.0"
+        xsi:schemaLocation="urn:switchyard-config:test-bean:1.0 ../composite/test/bean/bean.xsd"
+        name="m1app">
+    <sca:component name="FooExampleServiceBean">
+        <bean:implementation.bean class="com.example.switchyard.switchyard_example.FooExampleServiceBean"/>
+        <sca:service name="FooExampleService">
+            <sca:interface.java interface="com.example.switchyard.switchyard_example.ExampleService"/>
+        </sca:service>
+        <sca:reference name="FooExampleReference">
+            <sca:interface.java interface="com.example.switchyard.switchyard_example.ExampleService"/>
+        </sca:reference>
+    </sca:component>
+    <sca:component name="BarExampleServiceBean">
+        <bean:implementation.bean class="com.example.switchyard.switchyard_example.BarExampleServiceBean"/>
+        <sca:reference name="BarExampleReference">
+            <sca:interface.java interface="com.example.switchyard.switchyard_example.ExampleService"/>
+        </sca:reference>
+    </sca:component>
+    <sca:service multiplicity="0..1" name="SinglePromoteExampleService" promote="FooExampleServiceBean/FooExampleService">
+        <sca:interface.java interface="com.example.switchyard.switchyard_example.ExampleService"/>
+    </sca:service>
+    <sca:reference multiplicity="0..1" name="SinglePromoteExampleReference" promote="FooExampleServiceBean/FooExampleReference">
+        <sca:interface.java interface="com.example.switchyard.switchyard_example.ExampleService"/>
+    </sca:reference>
+    <sca:reference multiplicity="0..1" name="MultiPromoteExampleReference" promote="FooExampleServiceBean/FooExampleReference BarExampleServiceBean/BarExampleReference">
+        <sca:interface.java interface="com.example.switchyard.switchyard_example.ExampleService"/>
+    </sca:reference>
+</sca:composite>


### PR DESCRIPTION
SWITCHYARD-1544: Using the same promoted reference for two components causes issues in the model parser
https://issues.jboss.org/browse/SWITCHYARD-1544
