### PR TITLE
SWITCHYARD-1676 Allow common property separators

### DIFF
--- a/config/src/main/resources/org/switchyard/config/model/switchyard/v1/switchyard-v1.xsd
+++ b/config/src/main/resources/org/switchyard/config/model/switchyard/v1/switchyard-v1.xsd
@@ -284,7 +284,7 @@
     
     <simpleType name="propertyValue">
         <restriction base="string">
-            <pattern value="\$\{([a-zA-Z0-9])*(:([a-zA-Z0-9])*)?\}"/>
+            <pattern value="\$\{([a-zA-Z0-9\.-])*(:([a-zA-Z0-9])*)?\}"/>
         </restriction>
     </simpleType>
    

--- a/config/src/test/java/org/switchyard/config/model/switchyard/ThrottlingExtensionTests.java
+++ b/config/src/test/java/org/switchyard/config/model/switchyard/ThrottlingExtensionTests.java
@@ -27,6 +27,7 @@ import org.switchyard.config.model.switchyard.v1.V1ThrottlingModel;
 public class ThrottlingExtensionTests {
 
     private static final String THROTTLING_XML = "/org/switchyard/config/model/switchyard/ThrottlingExtensionTests.xml";
+    private static final String THROTTLING_XML2 = "/org/switchyard/config/model/switchyard/ThrottlingExtensionTests2.xml";
     private static final Integer MAX_REQUESTS = 50;
     private static final Long TIME_PERIOD = 2000L;
 
@@ -49,6 +50,17 @@ public class ThrottlingExtensionTests {
     @Test
     public void testRead() throws Exception {
         SwitchYardModel switchyard = _puller.pull(THROTTLING_XML, getClass());
+        ExtensionsModel extensions = switchyard.getComposite().getServices().get(0).getExtensions();
+        ThrottlingModel throttling = extensions.getThrottling();
+
+        Assert.assertEquals(MAX_REQUESTS, (Integer) throttling.getMaxRequests());
+        Assert.assertEquals(TIME_PERIOD, throttling.getTimePeriod());
+    }
+
+    @Test
+    public void testPropertySubstitution() throws Exception {
+        System.setProperty("property.messages.per.poll", "50");
+        SwitchYardModel switchyard = _puller.pull(THROTTLING_XML2, getClass());
         ExtensionsModel extensions = switchyard.getComposite().getServices().get(0).getExtensions();
         ThrottlingModel throttling = extensions.getThrottling();
 

--- a/config/src/test/resources/org/switchyard/config/model/switchyard/ThrottlingExtensionTests2.xml
+++ b/config/src/test/resources/org/switchyard/config/model/switchyard/ThrottlingExtensionTests2.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ - Copyright 2013 Red Hat Inc. and/or its affiliates and other contributors.
+ - 
+ - Licensed under the Apache License, Version 2.0 (the "License");
+ - you may not use this file except in compliance with the License.
+ - You may obtain a copy of the License at
+ - http://www.apache.org/licenses/LICENSE-2.0
+ - Unless required by applicable law or agreed to in writing, software
+ - distributed under the License is distributed on an "AS IS" BASIS,
+ - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ - See the License for the specific language governing permissions and
+ - limitations under the License.
+ -->
+<switchyard xmlns="urn:switchyard-config:switchyard:1.0"
+            xmlns:sy="urn:switchyard-config:switchyard:1.0"
+            xmlns:sca="http://docs.oasis-open.org/ns/opencsa/sca/200912"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xmlns:bean="urn:switchyard-config:test-bean:1.0"
+            xsi:schemaLocation="urn:switchyard-config:test-bean:1.0 ../composite/test/bean/bean.xsd"
+            name="m1app">
+    <sca:composite name="m1app" targetNamespace="urn:m1app:example:1.0">
+        <sca:service name="M1AppService" promote="SimpleService">
+            <sca:binding.sca sy:clustered="true"/>
+            <sca:extensions>
+                <sy:throttling timePeriod="2000" maxRequests="${property.messages.per.poll}"/>
+            </sca:extensions>
+        </sca:service>
+        <sca:reference name="M1AppReference" multiplicity="0..1" promote="SimpleService/anotherService">
+            <sca:binding.sca sy:clustered="true" 
+                sy:target="somethingElse" 
+                sy:targetNamespace="urn:another:uri" 
+                sy:loadBalance="RoundRobin"/>
+        </sca:reference>
+        <sca:component name="SimpleService">
+            <bean:implementation.bean class="org.switchyard.example.m1app.SimpleBean"/>
+            <sca:service name="SimpleService">
+                <sca:interface.java interface="org.switchyard.example.m1app.SimpleService"/>
+            </sca:service>
+            <sca:reference name="anotherService">
+                <sca:interface.java interface="org.switchyard.example.m1app.AnotherService"/>
+            </sca:reference>
+        </sca:component>
+    </sca:composite>
+</switchyard>


### PR DESCRIPTION
Allow common property separators.   Add a test to ThrottlingExtensionTests.java to test common property separators.
