### PR TITLE
SWITCHYARD-1771 Support remote transaction propagation via SCA binding

### DIFF
--- a/remote/src/main/java/org/switchyard/remote/http/HttpInvoker.java
+++ b/remote/src/main/java/org/switchyard/remote/http/HttpInvoker.java
@@ -20,6 +20,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 
 import org.jboss.logging.Logger;
+import org.switchyard.Property;
 import org.switchyard.remote.RemoteInvoker;
 import org.switchyard.remote.RemoteMessage;
 import org.switchyard.remote.RemoteMessages;
@@ -74,6 +75,10 @@ public class HttpInvoker implements RemoteInvoker {
         conn = (HttpURLConnection)_endpoint.openConnection();
         conn.setDoOutput(true);
         conn.addRequestProperty(SERVICE_HEADER, request.getService().toString());
+        for (Property prop : request.getContext().getProperties(HttpInvokerLabel.HAEDER.label())) {
+            conn.addRequestProperty(prop.getName(), prop.getValue().toString());
+        }
+        
         conn.connect();
         OutputStream os = conn.getOutputStream();
         try {

--- a/remote/src/main/java/org/switchyard/remote/http/HttpInvokerLabel.java
+++ b/remote/src/main/java/org/switchyard/remote/http/HttpInvokerLabel.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2013 Red Hat Inc. and/or its affiliates and other contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.switchyard.remote.http;
+
+import org.switchyard.label.Label;
+
+/**
+ * Represents httpinvoker labels.
+ */
+public enum HttpInvokerLabel implements Label {
+    /** httpinvoker labels. */
+    HAEDER;
+
+    private final String _label;
+
+    private HttpInvokerLabel() {
+        _label = Label.Util.toSwitchYardLabel("httpinvoker", name());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String label() {
+        return _label;
+    }
+
+    /**
+     * Gets the HttpInvokerLabel enum via case-insensitive short-name.
+     * @param name the case-insensitive short-name
+     * @return the HttpInvokerLabel enum
+     */
+    public static final HttpInvokerLabel ofName(String name) {
+        return Label.Util.ofName(HttpInvokerLabel.class, name);
+    }
+
+    /**
+     * Gets the full-form httpinvoker label from the case-insensitive short-name.
+     * @param name the case-insensitive short-name
+     * @return the full-form httpinvoker label
+     */
+    public static final String toLabel(String name) {
+        HttpInvokerLabel label = ofName(name);
+        return label != null ? label.label() : null;
+    }
+
+    /**
+     * Prints all known httpinvoker labels.
+     * @param args ignored
+     */
+    public static void main(String... args) {
+        Label.Util.print(values());
+    }
+}

--- a/runtime/src/main/java/org/switchyard/handlers/TransactionHandler.java
+++ b/runtime/src/main/java/org/switchyard/handlers/TransactionHandler.java
@@ -290,12 +290,18 @@ public class TransactionHandler implements ExchangeHandler {
         if (txStatus == Status.STATUS_MARKED_ROLLBACK) {
             try {
                 _transactionManager.rollback();
+                if (_log.isDebugEnabled()) {
+                    _log.debug("Transaction rolled back as it has been marked as RollbackOnly");
+                }
             } catch (Exception e) {
                 throw RuntimeMessages.MESSAGES.failedToRollbackTransaction(e);
             }
         } else if (txStatus == Status.STATUS_ACTIVE) {
             try {
                 _transactionManager.commit();
+                if (_log.isDebugEnabled()) {
+                    _log.debug("Transaction has been committed");
+                }
             } catch (Exception e) {
                 throw RuntimeMessages.MESSAGES.failedToCommitTransaction(e);
             }


### PR DESCRIPTION
Add HTTP header processing in HttpInvoker so it could deliver the transaction context which SCAInvoker expects.
