### PR TITLE
SWITCHYARD-366 Not doing autoboxing for primitive types

### DIFF
--- a/bus/camel/src/main/java/org/switchyard/bus/camel/CamelMessage.java
+++ b/bus/camel/src/main/java/org/switchyard/bus/camel/CamelMessage.java
@@ -26,6 +26,7 @@ import org.apache.camel.Exchange;
 import org.switchyard.Context;
 import org.switchyard.Message;
 import org.switchyard.common.camel.HandlerDataSource;
+import org.switchyard.common.camel.PrimitiveUnboxingUtil;
 import org.switchyard.common.camel.SwitchYardCamelContext;
 import org.switchyard.common.camel.SwitchYardMessage;
 import org.switchyard.label.BehaviorLabel;
@@ -97,6 +98,11 @@ public class CamelMessage extends SwitchYardMessage implements Message {
         if (transformedContent == null) {
             throw BusMessages.MESSAGES.transformerReturnedNull(body.getClass().getName(), type.getName(), transformer.getClass().getName());
         }
+
+        if (PrimitiveUnboxingUtil.isUnboxingException(type, transformedContent)) {
+            return PrimitiveUnboxingUtil.returnPrimitive(type, transformedContent);
+        }
+
         if (!type.isInstance(transformedContent)) {
             throw BusMessages.MESSAGES.transformerReturnedIncompatibleType(body.getClass().getName(), type.getName(), transformer.getClass().getName(), transformedContent.getClass().getName());
         }

--- a/common/camel/src/main/java/org/switchyard/common/camel/PrimitiveUnboxingUtil.java
+++ b/common/camel/src/main/java/org/switchyard/common/camel/PrimitiveUnboxingUtil.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2013 Red Hat Inc. and/or its affiliates and other contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.switchyard.common.camel;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Utility class that identifies primitive/wrapper combinations
+ * and can cast to primitive.
+ */
+public final class PrimitiveUnboxingUtil {
+    /*
+     * Map of primitive / wrappers
+     */
+    private static final Map<Class<?>, Class<?>> PRIMITIVE_CLASSES = 
+        new HashMap<Class<?>, Class<?>>();
+
+    static {
+        PRIMITIVE_CLASSES.put(boolean.class, Boolean.class);
+        PRIMITIVE_CLASSES.put(byte.class, Byte.class);
+        PRIMITIVE_CLASSES.put(char.class, Character.class);
+        PRIMITIVE_CLASSES.put(double.class, Double.class);
+        PRIMITIVE_CLASSES.put(float.class, Float.class);
+        PRIMITIVE_CLASSES.put(int.class, Integer.class);
+        PRIMITIVE_CLASSES.put(long.class, Long.class);
+        PRIMITIVE_CLASSES.put(short.class, Short.class);
+    }
+
+    private PrimitiveUnboxingUtil() {
+    }
+    
+    /**
+     * Checks to see if we have a primitive/wrapper combination that would allow us to
+     * unbox the class into the method's requested primitive.
+     * @param argType argType
+     * @param object object
+     * @return true/false
+     */
+    public static boolean isUnboxingException(Class<?> argType, Object object) {
+        if (PRIMITIVE_CLASSES.containsKey(argType)) {
+            return PRIMITIVE_CLASSES.get(argType).isInstance(object);
+        } else {
+            return false;
+        }
+    }
+
+    /**
+     * Returns the wrapper class cast.
+     * @param argType argType
+     * @param object object
+     * @param <T> <T>
+     * @return cast object
+     */
+    public static <T> T returnPrimitive(Class<T> argType, Object object) {
+        if (argType.isPrimitive()) {
+            T primitive = (T) object;
+            return primitive;
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
Need a check in CamelMessage for unboxing exceptions.     Added a Utility class to common/camel because we need to do the same check in components in Invocation.java.
