### PR TITLE
SWITCHYARD-1190 Please allow @Service with no args

### DIFF
--- a/common/core/src/main/java/org/switchyard/common/type/classpath/CompositeFilter.java
+++ b/common/core/src/main/java/org/switchyard/common/type/classpath/CompositeFilter.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2013 Red Hat Inc. and/or its affiliates and other contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.switchyard.common.type.classpath;
+
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Composite Filter holds multiple classpath filters.
+ */
+public class CompositeFilter extends AbstractTypeFilter {
+
+    private List<AbstractTypeFilter> _filters = new LinkedList<AbstractTypeFilter>();
+
+    /**
+     * Public constructor.
+     * @param filters filters to be held
+     */
+    public CompositeFilter(AbstractTypeFilter... filters) {
+        _filters.addAll(Arrays.asList(filters));
+    }
+    
+    /**
+     * Add a filter.
+     * @param filter a filter to add
+     * @return a reference to this filter instance
+     */
+    public CompositeFilter addFilter(AbstractTypeFilter filter) {
+        _filters.add(filter);
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean matches(Class<?> clazz) {
+        for (AbstractTypeFilter filter : _filters) {
+            if (!filter.matches(clazz)) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/common/core/src/main/java/org/switchyard/common/type/classpath/PackageFilter.java
+++ b/common/core/src/main/java/org/switchyard/common/type/classpath/PackageFilter.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2013 Red Hat Inc. and/or its affiliates and other contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.switchyard.common.type.classpath;
+
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Filter classpath classes besed on Java Package.
+ */
+public class PackageFilter extends AbstractTypeFilter {
+
+    private List<Package> _includes = new LinkedList<Package>();
+    private List<Package> _excludes = new LinkedList<Package>();
+
+    /**
+     * Public constructor.
+     * @param includes packages to be included
+     */
+    public PackageFilter(Package... includes) {
+        _includes.addAll(Arrays.asList(includes));
+    }
+    
+    /**
+     * Add a Package to be included.
+     * @param pkg a Package to include
+     * @return a reference to this filter instance
+     */
+    public PackageFilter addInclude(Package pkg) {
+        _includes.add(pkg);
+        return this;
+    }
+
+    /**
+     * Add a Package to be excluded.
+     * @param pkg a Package to exclude
+     * @return a reference to this filter instance
+     */
+    public PackageFilter addExclude(Package pkg) {
+        _excludes.add(pkg);
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean matches(Class<?> clazz) {
+        Package pkg = clazz.getPackage();
+        if (_includes.isEmpty()) {
+            return !_excludes.contains(pkg);
+        } else {
+            return _includes.contains(pkg) && !_excludes.contains(pkg);
+        }
+    }
+}

--- a/config/src/main/java/org/switchyard/config/model/ScannerInput.java
+++ b/config/src/main/java/org/switchyard/config/model/ScannerInput.java
@@ -32,12 +32,16 @@ public class ScannerInput<M extends Model> {
     private List<URL> _urls;
     private SwitchYardNamespace _switchyardNamespace;
     private String _compositeName;
+    private List<Package> _includes;
+    private List<Package> _excludes;
 
     /**
      * Constructs a new ScannerInput.
      */
     public ScannerInput() {
         _urls = new ArrayList<URL>();
+        _includes = new ArrayList<Package>();
+        _excludes = new ArrayList<Package>();
     }
 
     /**
@@ -59,6 +63,56 @@ public class ScannerInput<M extends Model> {
             for (URL url : urls) {
                 if (url != null) {
                     _urls.add(url);
+                }
+            }
+        }
+        return this;
+    }
+
+    /**
+     * Gets the Packages to include.
+     * @return the Packages
+     */
+    public synchronized List<Package> getIncludePackages() {
+        return Collections.unmodifiableList(_includes);
+    }
+
+    /**
+     * Sets the Packages to include.
+     * @param includes packages to include
+     * @return this ScannerInput (useful for chaining)
+     */
+    public synchronized ScannerInput<M> setIncludePackages(List<Package> includes) {
+        _includes.clear();
+        if (includes != null) {
+            for (Package p : includes) {
+                if (p != null) {
+                    _includes.add(p);
+                }
+            }
+        }
+        return this;
+    }
+
+    /**
+     * Gets the Packages to exclude.
+     * @return the Packages
+     */
+    public synchronized List<Package> getExcludePackages() {
+        return Collections.unmodifiableList(_excludes);
+    }
+
+    /**
+     * Sets the Packages to exclude.
+     * @param excludes packages to exclude
+     * @return this ScannerInput (useful for chaining)
+     */
+    public synchronized ScannerInput<M> setExcludePackages(List<Package> excludes) {
+        _excludes.clear();
+        if (excludes != null) {
+            for (Package p : excludes) {
+                if (p != null) {
+                    _excludes.add(p);
                 }
             }
         }
@@ -108,5 +162,5 @@ public class ScannerInput<M extends Model> {
         _compositeName = compositeName;
         return this;
     }
-
+    
 }


### PR DESCRIPTION
Added CompositeFilter and PackageFilter so that the BeanSwitchYardScanner could use IsAnnotationFilter and PackageFilter at the same time. BeanSwitchYardScanner raise an Exception against incomplete @Service annotated service like it doesn't have interface parameter while it implements multiple interfaces. Some of test classes actually have like that, so we need to exclude those with using PackageFilter.
