### PR TITLE
SWITCHYARD-1742: Bad parent pom version in core/serial/protostuff/pom.xml

### DIFF
--- a/serial/protostuff/pom.xml
+++ b/serial/protostuff/pom.xml
@@ -1,23 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- - Copyright 2013 Red Hat Inc. and/or its affiliates and other contributors.
- - 
- - Licensed under the Apache License, Version 2.0 (the "License");
- - you may not use this file except in compliance with the License.
- - You may obtain a copy of the License at
- - http://www.apache.org/licenses/LICENSE-2.0
- - Unless required by applicable law or agreed to in writing, software
- - distributed under the License is distributed on an "AS IS" BASIS,
- - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- - See the License for the specific language governing permissions and
- - limitations under the License.
- -->
+- Copyright 2013 Red Hat Inc. and/or its affiliates and other contributors.
+-
+- Licensed under the Apache License, Version 2.0 (the "License")
+- you may not use this file except in compliance with the License.
+- You may obtain a copy of the License at
+- http://www.apache.org/licenses/LICENSE-2.0
+- Unless required by applicable law or agreed to in writing, software
+- distributed under the License is distributed on an "AS IS" BASIS,
+- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+- See the License for the specific language governing permissions and
+- limitations under the License.
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.switchyard</groupId>
         <artifactId>switchyard-core-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <artifactId>switchyard-serial-protostuff</artifactId>
@@ -25,6 +25,9 @@
     <name>SwitchYard: Serial - Protostuff</name>
     <description>The Protostuff serialization library.</description>
     <url>http://switchyard.org</url>
+    <properties>
+        <version.protostuff>1.0.7</version.protostuff>
+    </properties>
     <dependencies>
         <!-- internal dependencies -->
         <dependency>
@@ -35,26 +38,32 @@
         <dependency>
             <groupId>com.dyuproject.protostuff</groupId>
             <artifactId>protostuff-api</artifactId>
+            <version>${version.protostuff}</version>
         </dependency>
         <dependency>
             <groupId>com.dyuproject.protostuff</groupId>
             <artifactId>protostuff-collectionschema</artifactId>
+            <version>${version.protostuff}</version>
         </dependency>
         <dependency>
             <groupId>com.dyuproject.protostuff</groupId>
             <artifactId>protostuff-core</artifactId>
+            <version>${version.protostuff}</version>
         </dependency>
         <dependency>
             <groupId>com.dyuproject.protostuff</groupId>
             <artifactId>protostuff-json</artifactId>
+            <version>${version.protostuff}</version>
         </dependency>
         <dependency>
             <groupId>com.dyuproject.protostuff</groupId>
             <artifactId>protostuff-runtime</artifactId>
+            <version>${version.protostuff}</version>
         </dependency>
         <dependency>
             <groupId>com.dyuproject.protostuff</groupId>
             <artifactId>protostuff-xml</artifactId>
+            <version>${version.protostuff}</version>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
SWITCHYARD-1742: Bad parent pom version in core/serial/protostuff/pom.xml
https://issues.jboss.org/browse/SWITCHYARD-1742
