### PR TITLE
SWITCHYARD-1995 Add a Dozer transformer quickstart

### DIFF
--- a/transform/src/main/java/org/switchyard/transform/dozer/internal/DozerTransformer.java
+++ b/transform/src/main/java/org/switchyard/transform/dozer/internal/DozerTransformer.java
@@ -18,7 +18,6 @@ import java.util.List;
 import javax.xml.namespace.QName;
 
 import org.dozer.DozerBeanMapper;
-import org.switchyard.Message;
 import org.switchyard.common.xml.QNameUtil;
 import org.switchyard.config.model.Scannable;
 import org.switchyard.transform.BaseTransformer;
@@ -27,7 +26,7 @@ import org.switchyard.transform.BaseTransformer;
  * Dozer {@link org.switchyard.transform.Transformer}.
  */
 @Scannable(false)
-public class DozerTransformer extends BaseTransformer<Message,Message> {
+public class DozerTransformer extends BaseTransformer {
 
     private DozerBeanMapper _dozerBeanMapper;
 
@@ -49,8 +48,7 @@ public class DozerTransformer extends BaseTransformer<Message,Message> {
      * {@inheritDoc}
      */
     @Override
-    public Message transform(Message message) {
-        Object result = _dozerBeanMapper.map(message.getContent(), QNameUtil.toJavaMessageType(getTo()));
-        return message.setContent(result);
+    public Object transform(Object message) {
+        return _dozerBeanMapper.map(message, QNameUtil.toJavaMessageType(getTo()));
     }
 }

--- a/transform/src/test/java/org/switchyard/transform/dozer/internal/DozerTransformerTest.java
+++ b/transform/src/test/java/org/switchyard/transform/dozer/internal/DozerTransformerTest.java
@@ -19,8 +19,6 @@ import java.io.IOException;
 import junit.framework.Assert;
 
 import org.junit.Test;
-import org.switchyard.Message;
-import org.switchyard.internal.DefaultMessage;
 import org.switchyard.transform.AbstractTransformerTestCase;
 import org.switchyard.transform.Transformer;
 
@@ -37,8 +35,8 @@ public class DozerTransformerTest extends AbstractTransformerTestCase {
         ClassA a = new ClassA();
         a.setFieldA("testa");
         a.setFieldB("testb");
-        Message msg = dozer.transform(new DefaultMessage().setContent(a));
-        Object result = msg.getContent();
+        
+        Object result = dozer.transform(a);
         Assert.assertTrue(result instanceof ClassB);
         ClassB b = ClassB.class.cast(result);
         Assert.assertEquals("testa", b.getFieldA());
@@ -53,8 +51,7 @@ public class DozerTransformerTest extends AbstractTransformerTestCase {
         ClassA a = new ClassA();
         a.setFieldA("testa");
         a.setFieldB("testb");
-        Message msg = dozer.transform(new DefaultMessage().setContent(a));
-        Object result = msg.getContent();
+        Object result = dozer.transform(a);
         Assert.assertTrue(result instanceof ClassB);
         ClassB b = ClassB.class.cast(result);
         Assert.assertEquals("testa", b.getFieldA());
@@ -72,8 +69,8 @@ public class DozerTransformerTest extends AbstractTransformerTestCase {
         ClassC c = new ClassC();
         c.setFieldA(a);
         c.setFieldC("testc");
-        Message msg = dozer.transform(new DefaultMessage().setContent(c));
-        Object result = msg.getContent();
+        
+        Object result = dozer.transform(c);
         Assert.assertTrue(result instanceof ClassD);
         ClassD d = ClassD.class.cast(result);
         ClassB b = d.getFieldB();


### PR DESCRIPTION
Changed the input/output for the transform() to Object instead of Message so it can work with message content directly since CamelMessage always passes message content to the transformer.
