### PR TITLE
SWITCHYARD-1951: JABMarshalTransformer uses unmarshalling error message

### DIFF
--- a/transform/src/main/java/org/switchyard/transform/TransformMessages.java
+++ b/transform/src/main/java/org/switchyard/transform/TransformMessages.java
@@ -358,6 +358,7 @@ public interface TransformMessages {
      * @param type type
      * @param e e
      * @return SwitchYardException
+     * @see #failedToMarshallForType(String, JAXBException)
      */
     @Message(id=16839, value = "Failed to unmarshall for type '%s'.")
     SwitchYardException failedToUnmarshallForType(String type, @Cause JAXBException e);
@@ -541,4 +542,15 @@ public interface TransformMessages {
      */
     @Message(id=16860, value = "Invalid 'to' type '%s' for Dozer transformer")
     SwitchYardException invalidToTypeForDozerTransformer(QName to);
+
+    /**
+     * failedToMarshallForType method definition.
+     * @param type type
+     * @param e e
+     * @return SwitchYardException
+     * @see #failedToUnmarshallForType(String, JAXBException)
+     */
+    @Message(id=16861, value = "Failed to marshall for type '%s'.")
+    SwitchYardException failedToMarshallForType(String type, @Cause JAXBException e);
+
 }

--- a/transform/src/main/java/org/switchyard/transform/jaxb/internal/JAXBMarshalTransformer.java
+++ b/transform/src/main/java/org/switchyard/transform/jaxb/internal/JAXBMarshalTransformer.java
@@ -81,7 +81,7 @@ public class JAXBMarshalTransformer<F, T> extends BaseTransformer<Message, Messa
 
             message.setContent(resultWriter.toString());
         } catch (JAXBException e) {
-            throw TransformMessages.MESSAGES.failedToUnmarshallForType(getFrom().toString(), e);
+            throw TransformMessages.MESSAGES.failedToMarshallForType(getFrom().toString(), e);
         }
 
         return message;


### PR DESCRIPTION
SWITCHYARD-1951: JABMarshalTransformer uses unmarshalling error message
https://issues.jboss.org/browse/SWITCHYARD-1951
