### PR TITLE
SWITCHYARD-1981 Provide sensible names for internal camel routes

### DIFF
--- a/common/camel/src/main/java/org/switchyard/common/camel/SwitchYardCamelContext.java
+++ b/common/camel/src/main/java/org/switchyard/common/camel/SwitchYardCamelContext.java
@@ -208,6 +208,12 @@ public class SwitchYardCamelContext extends DefaultCamelContext {
             timeout = DEFAULT_TIMEOUT;
         }
         getShutdownStrategy().setTimeout(timeout);
+        
+        if (_domain.getName() != null) {
+            // Need to replace colons to make a valid ObjectName
+            setName(_domain.getName().toString().replace(':', '-'));
+        }
+
     }
 
 }

--- a/deploy/base/src/main/java/org/switchyard/deploy/internal/AbstractDeployment.java
+++ b/deploy/base/src/main/java/org/switchyard/deploy/internal/AbstractDeployment.java
@@ -117,16 +117,7 @@ public abstract class AbstractDeployment {
             throw new IllegalArgumentException("null 'appServiceDomain' argument.");
         }
         
-        // initialize deployment name
-        if (getConfig() != null) {
-            _name = getConfig().getQName();
-            if (_name == null) {
-                // initialize to composite name if config name is missing
-                if (getConfig().getComposite() != null) {
-                    _name = getConfig().getComposite().getQName();
-                }
-            }
-        }
+        initName();
         
         _serviceDomain = appServiceDomain;
         _serviceDomain.setProperty(CLASSLOADER_PROPERTY, Classes.getTCCL());
@@ -137,6 +128,26 @@ public abstract class AbstractDeployment {
         _validatorRegistryLoader.loadOOTBValidates();
         
         doInit(activators);
+    }
+
+    /**
+     * Initialises the deployment name.
+     */
+    public final void initName() {
+    	if (_name != null) {
+    		return;
+    	}
+    	
+        // initialize deployment name
+        if (getConfig() != null) {
+            _name = getConfig().getQName();
+            if (_name == null) {
+                // initialize to composite name if config name is missing
+                if (getConfig().getComposite() != null) {
+                    _name = getConfig().getComposite().getQName();
+                }
+            }
+        }
     }
 
 


### PR DESCRIPTION
The mbeans tree now looks like this image
![mbeans](https://f.cloud.github.com/assets/650600/2418246/47dbf7fe-ab3c-11e3-8ed0-a1be65385550.png)
