### PR TITLE
SWITCHYARD-2014 Transaction policy is lost if promoted name is different

### DIFF
--- a/deploy/base/src/main/java/org/switchyard/deploy/internal/Deployment.java
+++ b/deploy/base/src/main/java/org/switchyard/deploy/internal/Deployment.java
@@ -564,7 +564,7 @@ public class Deployment extends AbstractDeployment {
                         if (!service.getQName().equals(compositeService.getQName())) {
                             validateServiceRegistration(compositeService.getQName());
                             Service promotedService = getDomain().registerService(
-                                    compositeService.getQName(), serviceIntf, handler);
+                                    compositeService.getQName(), serviceIntf, handler, metadata);
                             activation.addPromotion(promotedService);
                         }
                     }

--- a/deploy/base/src/test/java/org/switchyard/deploy/internal/DeploymentTest.java
+++ b/deploy/base/src/test/java/org/switchyard/deploy/internal/DeploymentTest.java
@@ -43,6 +43,7 @@ import org.switchyard.extensions.wsdl.WSDLService;
 import org.switchyard.internal.DomainImpl;
 import org.switchyard.metadata.ServiceInterface;
 import org.switchyard.metadata.ServiceOperation;
+import org.switchyard.policy.TransactionPolicy;
 import org.switchyard.spi.ServiceRegistry;
 import org.switchyard.transform.Transformer;
 import org.switchyard.validate.Validator;
@@ -119,8 +120,17 @@ public class DeploymentTest {
         Service implService = deployment.getDomain().getServices(
                 new QName("urn:test:config-mock-binding:1.0", "TestService")).get(0);
         Assert.assertNotNull(implService.getServiceMetadata().getRegistrant());
+        Assert.assertTrue(implService.getServiceMetadata().getRequiredPolicies().contains(TransactionPolicy.MANAGED_TRANSACTION_GLOBAL));
+        Assert.assertTrue(implService.getServiceMetadata().getRequiredPolicies().contains(TransactionPolicy.PROPAGATES_TRANSACTION));
         Assert.assertTrue(implService.getServiceMetadata().getRegistrant().getConfig() instanceof ComponentImplementationModel);
         
+        Service promotedService = deployment.getDomain().getServices(
+                new QName("urn:test:config-mock-binding:1.0", "PromotedTestService")).get(0);
+        Assert.assertNotNull(promotedService.getServiceMetadata().getRegistrant());
+        Assert.assertTrue(promotedService.getServiceMetadata().getRequiredPolicies().contains(TransactionPolicy.MANAGED_TRANSACTION_GLOBAL));
+        Assert.assertTrue(promotedService.getServiceMetadata().getRequiredPolicies().contains(TransactionPolicy.PROPAGATES_TRANSACTION));
+        Assert.assertTrue(promotedService.getServiceMetadata().getRegistrant().getConfig() instanceof ComponentImplementationModel);
+
         Service bindingService = deployment.getDomain().getServices(
                 new QName("urn:test:config-mock-binding:1.0", "TestReference")).get(0);
         Assert.assertNotNull(bindingService.getServiceMetadata().getRegistrant());
@@ -133,7 +143,7 @@ public class DeploymentTest {
         Assert.assertTrue(implReference.getServiceMetadata().getRegistrant().getConfig() instanceof ComponentImplementationModel);
         
         ServiceReference bindingReference = deployment.getDomain().getServiceReference(
-                new QName("urn:test:config-mock-binding:1.0", "TestService"));
+                new QName("urn:test:config-mock-binding:1.0", "PromotedTestService"));
         Assert.assertNotNull(bindingReference.getServiceMetadata().getRegistrant());
         List<BindingModel> refBindings = bindingReference.getServiceMetadata().getRegistrant().getConfig();
         Assert.assertEquals(2, refBindings.size());

--- a/deploy/base/src/test/resources/switchyard-config-mock-01.xml
+++ b/deploy/base/src/test/resources/switchyard-config-mock-01.xml
@@ -18,7 +18,7 @@
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xsi:schemaLocation="urn:switchyard-component-mock:config:1.0 org/switchyard/component/mock/config/model/v1/mock_1_0.xsd">
     <sca:composite name="mockBinding" targetNamespace="urn:test:config-mock-binding:1.0">
-        <sca:service name="TestService" promote="TestService">
+        <sca:service name="PromotedTestService" promote="TestService">
             <mock:binding.mock name="binding1"/>
             <mock:binding.mock name="binding2"/>
         </sca:service>
@@ -26,8 +26,8 @@
             <mock:binding.mock/>
         </sca:reference>
         <sca:component name="TestService">
-            <mock:implementation.mock/>
-            <sca:service name="TestService">
+            <mock:implementation.mock requires="managedTransaction.Global"/>
+            <sca:service name="TestService" requires="propagatesTransaction">
                 <mock:interface.mock/>
             </sca:service>
             <sca:reference name="TestReference">


### PR DESCRIPTION
short term fix for this issue - it should be fixed cleanly with service wiring addressed by SWITCHYARD-1525
