### PR TITLE
SWITCHYARD-2091 Verify functionality of validation components in Karaf

### DIFF
--- a/deploy/karaf/src/main/resources/features.xml
+++ b/deploy/karaf/src/main/resources/features.xml
@@ -297,4 +297,9 @@
         <bundle>mvn:org.switchyard.quickstarts/switchyard-camel-sql-binding/${project.version}</bundle>
     </feature>
 
+    <feature name="switchyard-quickstart-validate-xml" version="${project.version}" resolver="(obr)">
+        <feature version="${project.version}">switchyard-bean</feature>
+        <feature version="${project.version}">switchyard-soap</feature>
+        <bundle>mvn:org.switchyard.quickstarts/switchyard-validate-xml/${project.version}</bundle>
+    </feature>
 </features>


### PR DESCRIPTION
Initial work to get validate-xml quickstart deployed on karaf. Note it still fails with SWITCHYARD-2118.
