### PR TITLE
SWITCHYARD-2101 Added propFloat and propDouble to the switchyard schema

### DIFF
--- a/config/src/main/resources/org/switchyard/config/model/switchyard/v2/switchyard_2_0.xsd
+++ b/config/src/main/resources/org/switchyard/config/model/switchyard/v2/switchyard_2_0.xsd
@@ -278,6 +278,14 @@
         <union memberTypes="long swyd:propertyValue"/>
     </simpleType>
     
+    <simpleType name="propFloat">
+        <union memberTypes="float swyd:propertyValue"/>
+    </simpleType>
+
+    <simpleType name="propDouble">
+        <union memberTypes="double swyd:propertyValue"/>
+    </simpleType>
+
     <simpleType name="propBoolean">
         <union memberTypes="boolean swyd:propertyValue"/>
     </simpleType>


### PR DESCRIPTION
propDouble is used for camel-mqtt schema. propFloat is just an premium for future use.
