### PR TITLE
SWITCHYARD-2220 Unable to find BeanManager error on executing mqtt quick...

### DIFF
--- a/bus/camel/src/main/java/org/switchyard/bus/camel/CamelExchangeBus.java
+++ b/bus/camel/src/main/java/org/switchyard/bus/camel/CamelExchangeBus.java
@@ -60,6 +60,12 @@ public class CamelExchangeBus implements ExchangeBus {
         for (Processors processor : Processors.values()) {
             registry.put(processor.name(), processor.create(domain));
         }
+
+        // CAMEL-7728 introduces an issue on finding BeanManager due to the fact that default
+        // applicationContextClassLoader in the CamelContext is not a bundle deployment class loader.
+        // We need to ensure the applicationContextClassLoader is the bundle deployment class loader
+        // for now. This will be unnecessary once CAMEL-7759 is merged.
+        _camelContext.setApplicationContextClassLoader(Thread.currentThread().getContextClassLoader());
     }
 
     /**


### PR DESCRIPTION
...start on karaf

Set a deployment class loader as a CamelContext applicationClassLoader. CAMEL-7728 fix introduces another issue due to the CamelContext applicationClassLoader is not initialized with the bundle deployment class loader.
