### PR TITLE
SWITCHYARD-2001 Enforce Policy dependencies

### DIFF
--- a/deploy/base/src/main/java/org/switchyard/deploy/BaseDeployLogger.java
+++ b/deploy/base/src/main/java/org/switchyard/deploy/BaseDeployLogger.java
@@ -1,13 +1,13 @@
 package org.switchyard.deploy;
 
 import static org.jboss.logging.Logger.Level.ERROR;
+import static org.jboss.logging.Logger.Level.INFO;
 
 import org.jboss.logging.Logger;
 import org.jboss.logging.annotations.MessageLogger;
 import org.jboss.logging.annotations.Cause;
 import org.jboss.logging.annotations.LogMessage;
 import org.jboss.logging.annotations.Message;
-
 /**
  * <p/>
  * This file is using the subset 12000-12199 for logger messages.
@@ -70,4 +70,22 @@ public interface BaseDeployLogger {
     @LogMessage(level = ERROR) 
     @Message(id = 10905, value="Error deactivating reference binding.")
     void errorDeactivatingReferenceBinding(@Cause Throwable e);
+    
+    /**
+     * enforcingInteractionPolicyDependency method definition.
+     * @param dependency dependency
+     * @param subject subject
+     */
+    @LogMessage(level = INFO)
+    @Message(id = 10906, value="Enforcing %s interaction policy as a dependency of %s")
+    void enforcingInteractionPolicyDependency(String dependency, String subject);
+
+    /**
+     * enforcingImplementationPolicyDependency method definition.
+     * @param dependency dependency
+     * @param subject subject
+     */
+    @LogMessage(level = INFO)
+    @Message(id = 10907, value="Enforcing %s implementation policy as a dependency of %s")
+    void enforcingImplementationPolicyDependency(String dependency, String subject);
 }

--- a/deploy/base/src/test/resources/switchyard-config-policy-tx-managedLocal-invalid.xml
+++ b/deploy/base/src/test/resources/switchyard-config-policy-tx-managedLocal-invalid.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ - Copyright 2013 Red Hat Inc. and/or its affiliates and other contributors.
+ - 
+ - Licensed under the Apache License, Version 2.0 (the "License");
+ - you may not use this file except in compliance with the License.
+ - You may obtain a copy of the License at
+ - http://www.apache.org/licenses/LICENSE-2.0
+ - Unless required by applicable law or agreed to in writing, software
+ - distributed under the License is distributed on an "AS IS" BASIS,
+ - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ - See the License for the specific language governing permissions and
+ - limitations under the License.
+ -->
+<switchyard xmlns="urn:switchyard-config:switchyard:1.0"
+            xmlns:sca="http://docs.oasis-open.org/ns/opencsa/sca/200912"
+            xmlns:mock="urn:switchyard-component-mock:config:1.0"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="urn:switchyard-component-mock:config:1.0 org/switchyard/component/mock/config/model/v1/mock_1_0.xsd">
+    <sca:composite name="mockBinding" targetNamespace="urn:test:config-mock-binding:1.0">
+        <sca:service name="PromotedTestService" promote="TestService">
+            <mock:binding.mock name="binding1"/>
+            <mock:binding.mock name="binding2"/>
+        </sca:service>
+        <sca:reference name="TestReference" promote="TestService/TestReference">
+            <mock:binding.mock/>
+        </sca:reference>
+        <sca:component name="TestService">
+            <mock:implementation.mock requires="managedTransaction.Local"/>
+            <sca:service name="TestService" requires="propagatesTransaction">
+                <mock:interface.mock/>
+            </sca:service>
+            <sca:reference name="TestReference">
+                <mock:interface.mock/>
+            </sca:reference>
+        </sca:component>
+        <sca:component name="NoService">
+            <mock:implementation.mock/>
+            <sca:reference name="TestReference">
+                <mock:interface.mock/>
+            </sca:reference>
+        </sca:component>
+    </sca:composite>
+</switchyard>

--- a/deploy/base/src/test/resources/switchyard-config-policy-tx-managedLocal.xml
+++ b/deploy/base/src/test/resources/switchyard-config-policy-tx-managedLocal.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ - Copyright 2013 Red Hat Inc. and/or its affiliates and other contributors.
+ - 
+ - Licensed under the Apache License, Version 2.0 (the "License");
+ - you may not use this file except in compliance with the License.
+ - You may obtain a copy of the License at
+ - http://www.apache.org/licenses/LICENSE-2.0
+ - Unless required by applicable law or agreed to in writing, software
+ - distributed under the License is distributed on an "AS IS" BASIS,
+ - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ - See the License for the specific language governing permissions and
+ - limitations under the License.
+ -->
+<switchyard xmlns="urn:switchyard-config:switchyard:1.0"
+            xmlns:sca="http://docs.oasis-open.org/ns/opencsa/sca/200912"
+            xmlns:mock="urn:switchyard-component-mock:config:1.0"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="urn:switchyard-component-mock:config:1.0 org/switchyard/component/mock/config/model/v1/mock_1_0.xsd">
+    <sca:composite name="mockBinding" targetNamespace="urn:test:config-mock-binding:1.0">
+        <sca:service name="PromotedTestService" promote="TestService">
+            <mock:binding.mock name="binding1"/>
+            <mock:binding.mock name="binding2"/>
+        </sca:service>
+        <sca:reference name="TestReference" promote="TestService/TestReference">
+            <mock:binding.mock/>
+        </sca:reference>
+        <sca:component name="TestService">
+            <mock:implementation.mock requires="managedTransaction.Local"/>
+            <sca:service name="TestService">
+                <mock:interface.mock/>
+            </sca:service>
+            <sca:reference name="TestReference">
+                <mock:interface.mock/>
+            </sca:reference>
+        </sca:component>
+        <sca:component name="NoService">
+            <mock:implementation.mock/>
+            <sca:reference name="TestReference">
+                <mock:interface.mock/>
+            </sca:reference>
+        </sca:component>
+    </sca:composite>
+</switchyard>


### PR DESCRIPTION
It used to just raise a validation error if policy dependency is not satisfied, changed to add the dependency automatically.
