### PR TITLE
SWITCHYARD-2415 StackOverflowError thrown when service with selfrefering...

### DIFF
--- a/config/src/main/java/org/switchyard/config/model/property/v1/V1PropertyModel.java
+++ b/config/src/main/java/org/switchyard/config/model/property/v1/V1PropertyModel.java
@@ -26,6 +26,8 @@ import org.switchyard.config.model.property.PropertyModel;
  */
 public class V1PropertyModel extends BaseModel implements PropertyModel {
 
+    private boolean _valueRecursionCheck;
+
     /**
      * Creates a new PropertyModel in the specified namespace.
      * @param namespace the specified namespace
@@ -72,8 +74,16 @@ public class V1PropertyModel extends BaseModel implements PropertyModel {
      * {@inheritDoc}
      */
     @Override
-    public String getValue() {
-        return getModelAttribute("value");
+    public synchronized String getValue() {
+        if (_valueRecursionCheck) {
+            return null;
+        }
+        _valueRecursionCheck = true;
+        try {
+            return getModelAttribute("value");
+        } finally {
+            _valueRecursionCheck = false;
+        }
     }
 
     /**

--- a/config/src/test/java/org/switchyard/config/model/composite/CompositeModelTests.java
+++ b/config/src/test/java/org/switchyard/config/model/composite/CompositeModelTests.java
@@ -23,13 +23,14 @@ import java.io.StringReader;
 
 import javax.xml.namespace.QName;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 
 import org.custommonkey.xmlunit.Diff;
 import org.custommonkey.xmlunit.XMLUnit;
 import org.junit.Before;
 import org.junit.Test;
 import org.switchyard.common.io.pull.StringPuller;
+import org.switchyard.common.lang.Strings;
 import org.switchyard.common.property.PropertyResolver;
 import org.switchyard.common.xml.XMLHelper;
 import org.switchyard.config.Configuration;
@@ -58,6 +59,7 @@ public class CompositeModelTests {
     private static final String EXTENSION_XML = "/org/switchyard/config/model/composite/CompositeModelTests-Extension.xml";
     private static final String SCA_BINDING_XML = "/org/switchyard/config/model/composite/CompositeModelTests-SCABinding.xml";
     private static final String PROMOTE_XML = "/org/switchyard/config/model/composite/CompositeModelTests-Promote.xml";
+    private static final String PROPERTIES_SELF_REFERRING_XML = "/org/switchyard/config/model/composite/CompositeModelTests-PropertiesSelfReferring.xml";
 
     private static ModelPuller<CompositeModel> _puller;
 
@@ -200,6 +202,27 @@ public class CompositeModelTests {
         assertEquals("component." + System.getProperty("user.name"), componentPr.resolveProperty("component.userName"));
     }
     
+    @Test
+    public void testSelfReferringPropertyModel() throws Exception {
+        CompositeModel composite = _puller.pull(PROPERTIES_SELF_REFERRING_XML, getClass());
+        // Test component property
+        ComponentModel component = composite.getComponents().get(1);
+        assertEquals(5, component.getProperties().size());
+        PropertyResolver componentPr = component.getModelConfiguration().getPropertyResolver();
+
+        Object result = componentPr.resolveProperty("creditTerms");
+        assertTrue("${creditTerms}".equals(result));
+
+        result = componentPr.resolveProperty("foobar");
+        assertTrue("foobar".equals((String) result));
+
+        result = componentPr.resolveProperty("bar");
+        assertTrue("${bar}".equals(result));
+
+        result = componentPr.resolveProperty("bar");
+        assertTrue("${bar}".equals(result));
+    }
+
     @Test
     public void testWriteComplete() throws Exception {
         String old_xml = new StringPuller().pull(COMPLETE_XML, getClass());

--- a/config/src/test/resources/org/switchyard/config/model/composite/CompositeModelTests-PropertiesSelfReferring.xml
+++ b/config/src/test/resources/org/switchyard/config/model/composite/CompositeModelTests-PropertiesSelfReferring.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ - Copyright 2013 Red Hat Inc. and/or its affiliates and other contributors.
+ -
+ - Licensed under the Apache License, Version 2.0 (the "License");
+ - you may not use this file except in compliance with the License.
+ - You may obtain a copy of the License at
+ - http://www.apache.org/licenses/LICENSE-2.0
+ - Unless required by applicable law or agreed to in writing, software
+ - distributed under the License is distributed on an "AS IS" BASIS,
+ - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ - See the License for the specific language governing permissions and
+ - limitations under the License.
+ -->
+<composite xmlns="http://docs.oasis-open.org/ns/opencsa/sca/200912"
+           targetNamespace="urn:mortgages:1.0"
+           xmlns:bean="urn:switchyard-config:test-bean:1.0"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           name="mortgages">
+    <component name="CreditServiceBean">
+      <bean:implementation.bean class="mortgages.CreditServiceBean"/>
+      <service name="CreditService">
+        <interface.java interface="mortgages.CreditService"/>
+      </service>
+    </component>
+    <component name="QualificationServiceBean">
+      <bean:implementation.bean class="mortgages.QualificationServiceBean"/>
+      <service name="QualificationService">
+        <interface.java interface="mortgages.QualificationService"/>
+      </service>
+      <property value="${creditTerms}" name="creditTerms"/>
+      <property value="foobar" name="foobar"/>
+      
+      <property value="${foo}" name="bar"/>
+      <property value="${fubar}" name="foo"/>
+      <property value="${bar}" name="fubar"/>
+    </component>
+</composite>


### PR DESCRIPTION
StackOverflowError thrown when service with selfrefering implementation property is deployed.

@errantepiphany : Am I on the right track here?   I couldn't find a way of checking the unresolved value of the property unless I added a method to configuration that returned an attribute unresolved.     

The SystemResolver always tries to resolve before the ComponentModel, right?  I don't want to be throwing RuntimeExceptions if the property is going to resolve by system env variable.
