### PR TITLE
SWITCHYARD-2399 Seeing conflict in deltaspike dependencies between switchyard-common-cdi and camel-cdi

### DIFF
--- a/common/camel/pom.xml
+++ b/common/camel/pom.xml
@@ -59,6 +59,16 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-cdi</artifactId>
+            <exclusions>
+                <exclusion>
+                    <artifactId>deltaspike-core-impl</artifactId>
+                    <groupId>org.apache.deltaspike.core</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>deltaspike-cdictrl-api</artifactId>
+                    <groupId>org.apache.deltaspike.cdictrl</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.camel</groupId>

--- a/tools/maven/plugins/switchyard/pom.xml
+++ b/tools/maven/plugins/switchyard/pom.xml
@@ -81,6 +81,12 @@
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-plugin-api</artifactId>
+	    <exclusions>
+              <exclusion>
+                     <groupId>org.sonatype.sisu</groupId>
+                     <artifactId>sisu-guava</artifactId>
+              </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
Found two version mismatches - a version clash in deltaspike dependencies which led to a ClassNotFoundException when running SwitchYard tests, and a org.sonatype/com.google guava clash that caused an exception due to method parameter differences.  Excluding the two offending deltaspike dependencies and the org.sonatype guava dependency.
