### PR TITLE
SWITCHYARD-2416: Exception not thrown when remote SCA fails while unmarshalling object

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,7 @@
         <module>config</module>
         <module>serial/base</module>
         <module>serial/jackson</module>
+        <!-- <module>serial/protostuff</module> -->
         <module>security/base</module>
         <module>security/jboss</module>
         <module>security/karaf</module>

--- a/serial/base/src/main/java/org/switchyard/serial/SerialLogger.java
+++ b/serial/base/src/main/java/org/switchyard/serial/SerialLogger.java
@@ -1,6 +1,10 @@
 package org.switchyard.serial;
 
+import static org.jboss.logging.Logger.Level.WARN;
+
 import org.jboss.logging.Logger;
+import org.jboss.logging.annotations.LogMessage;
+import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageLogger;
 
 /**
@@ -11,8 +15,19 @@ import org.jboss.logging.annotations.MessageLogger;
  */
 @MessageLogger(projectCode = "SWITCHYARD")
 public interface SerialLogger {
+
     /**
      * Default root logger.
      */
     SerialLogger ROOT_LOGGER = Logger.getMessageLogger(SerialLogger.class, SerialLogger.class.getPackage().getName());
+
+    /**
+     * classUnsupportedByFactory method definition.
+     * @param className className
+     * @param factoryClassName factoryClassName
+     */
+    @LogMessage(level = WARN)
+    @Message(id = 15000, value = "Class [%s] unsupported by Factory [%s]; returning null")
+    void classUnsupportedByFactoryReturningNull(String className, String factoryClassName);
+
 }

--- a/serial/base/src/main/java/org/switchyard/serial/SerialMessages.java
+++ b/serial/base/src/main/java/org/switchyard/serial/SerialMessages.java
@@ -13,6 +13,7 @@ import org.switchyard.SwitchYardException;
  */
 @MessageBundle(projectCode = "SWITCHYARD")
 public interface SerialMessages {
+
     /**
      * Default messages. 
      */
@@ -21,9 +22,10 @@ public interface SerialMessages {
     /**
      * couldNotInstantiateThrowable method definition.
      * @param className className
+     * @param cause cause
      * @return SwitchYardException
      */
-    @Message(id=15200, value = "Could not instantiate Throwable class: %s")
-    SwitchYardException couldNotInstantiateThrowable(String className);
+    @Message(id=15200, value = "Could not instantiate Throwable class [%s] because [%s]")
+    SwitchYardException couldNotInstantiateThrowable(String className, String cause);
 
 }

--- a/serial/base/src/main/java/org/switchyard/serial/graph/Graph.java
+++ b/serial/base/src/main/java/org/switchyard/serial/graph/Graph.java
@@ -94,6 +94,22 @@ public final class Graph implements Serializable {
     }
 
     /**
+     * Gets a reference id with the specified object.
+     * @param obj the specified object
+     * @return the reference id
+     */
+    public Integer getReferenceId(Object obj) {
+        if (obj != null) {
+            for (Map.Entry<Integer, Object> entry : _references.entrySet()) {
+                if (entry.getValue() == obj) {
+                    return entry.getKey();
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
      * Puts a reference with the specified id.
      * @param id the specified id
      * @param obj the reference

--- a/serial/base/src/main/java/org/switchyard/serial/graph/node/AccessNode.java
+++ b/serial/base/src/main/java/org/switchyard/serial/graph/node/AccessNode.java
@@ -34,6 +34,7 @@ import org.switchyard.common.type.reflect.Access;
 import org.switchyard.common.type.reflect.BeanAccess;
 import org.switchyard.common.type.reflect.FieldAccess;
 import org.switchyard.common.type.reflect.MethodAccess;
+import org.switchyard.serial.SerialLogger;
 import org.switchyard.serial.graph.AccessType;
 import org.switchyard.serial.graph.CoverageType;
 import org.switchyard.serial.graph.Exclude;
@@ -129,7 +130,14 @@ public abstract class AccessNode implements Node {
         }
         final Class clazz = (Class)graph.decomposeReference(getClazz());
         final Factory factory = Factory.getFactory(clazz);
-        final Object obj = factory.supports(clazz) ? factory.create(clazz, this) : null;
+        final Object obj;
+        if (factory.supports(clazz)) {
+            obj = factory.create(clazz, this);
+        } else {
+            final String className = clazz != null ? clazz.getName() : "null";
+            SerialLogger.ROOT_LOGGER.classUnsupportedByFactoryReturningNull(className, factory.getClass().getName());
+            obj = null;
+        }
         Map<String, Integer> ids = getIds();
         if (obj != null && ids != null) {
             for (final Access access : getAccessList(clazz)) {

--- a/serial/base/src/main/java/org/switchyard/serial/graph/node/ThrowableAccessNode.java
+++ b/serial/base/src/main/java/org/switchyard/serial/graph/node/ThrowableAccessNode.java
@@ -13,6 +13,7 @@
  */
 package org.switchyard.serial.graph.node;
 
+import java.lang.reflect.UndeclaredThrowableException;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
@@ -179,7 +180,15 @@ public final class ThrowableAccessNode extends AccessNode {
         Throwable throwable = (Throwable)super.decompose(graph);
         Throwable cause = (Throwable)graph.decomposeReference(getCause());
         if (cause != null) {
-            throwable.initCause(cause);
+            if (UndeclaredThrowableException.class.equals(throwable.getClass())) {
+                Integer referenceId = graph.getReferenceId(throwable);
+                throwable = new UndeclaredThrowableException(cause, throwable.getMessage());
+                if (referenceId != null) {
+                    graph.putReference(referenceId, throwable);
+                }
+            } else {
+                throwable.initCause(cause);
+            }
         }
         Object[] array = (Object[])graph.decomposeReference(getStackTrace());
         if (array != null) {

--- a/serial/jackson/src/test/java/org/switchyard/serial/jackson/JacksonComparisonSerializationTest.java
+++ b/serial/jackson/src/test/java/org/switchyard/serial/jackson/JacksonComparisonSerializationTest.java
@@ -13,8 +13,7 @@
  */
 package org.switchyard.serial.jackson;
 
-import junit.framework.Assert;
-
+import org.junit.Assert;
 import org.junit.Test;
 import org.switchyard.serial.CompressionType;
 import org.switchyard.serial.FormatType;

--- a/serial/jackson/src/test/java/org/switchyard/serial/jackson/JacksonComplexSerializationTest.java
+++ b/serial/jackson/src/test/java/org/switchyard/serial/jackson/JacksonComplexSerializationTest.java
@@ -14,6 +14,7 @@
 package org.switchyard.serial.jackson;
 
 import java.io.StringReader;
+import java.lang.reflect.UndeclaredThrowableException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -24,8 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-import junit.framework.Assert;
-
+import org.junit.Assert;
 import org.junit.Test;
 import org.switchyard.HandlerException;
 import org.switchyard.common.io.pull.ElementPuller;
@@ -215,6 +215,23 @@ public final class JacksonComplexSerializationTest {
         Assert.assertEquals(expectedOutOfGasException.getExplicitive(), actualOutOfGasException.getExplicitive());
         Assert.assertSame(expectedFlatTireException.getWheel().getLocation(), actualFlatTireException.getWheel().getLocation());
         Assert.assertEquals("Really?", actualFlatTireException.getMessage());
+    }
+
+    @Test
+    public void testUndeclaredThrowableException() throws Exception {
+        final UndeclaredThrowableException expectedUndeclaredThrowableException = new UndeclaredThrowableException(new Throwable("undeclared"), "message");
+        Car car = new Car();
+        car.setProblems(Arrays.asList(new Exception[]{expectedUndeclaredThrowableException, expectedUndeclaredThrowableException}));
+        car = serDeser(car, Car.class);
+        final List<Exception> actualExceptions = car.getProblems();
+        final UndeclaredThrowableException actualUndeclaredThrowableException = (UndeclaredThrowableException)actualExceptions.get(0);
+        final UndeclaredThrowableException sameUndeclaredThrowableException = (UndeclaredThrowableException)actualExceptions.get(1);
+        Assert.assertSame(actualUndeclaredThrowableException, sameUndeclaredThrowableException);
+        Assert.assertEquals("message", actualUndeclaredThrowableException.getMessage());
+        Assert.assertEquals(expectedUndeclaredThrowableException.getMessage(), actualUndeclaredThrowableException.getMessage());
+        Assert.assertEquals(expectedUndeclaredThrowableException.getStackTrace().length, actualUndeclaredThrowableException.getStackTrace().length);
+        Assert.assertEquals("undeclared", actualUndeclaredThrowableException.getUndeclaredThrowable().getMessage());
+        Assert.assertSame(actualUndeclaredThrowableException.getUndeclaredThrowable(), actualUndeclaredThrowableException.getCause());
     }
 
     @Test

--- a/serial/protostuff/pom.xml
+++ b/serial/protostuff/pom.xml
@@ -21,15 +21,22 @@
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <artifactId>switchyard-serial-protostuff</artifactId>
-    <packaging>jar</packaging>
+    <packaging>bundle</packaging>
     <name>SwitchYard: Serial - Protostuff</name>
     <description>The Protostuff serialization library.</description>
     <url>http://switchyard.org</url>
     <properties>
-        <version.protostuff>1.0.7</version.protostuff>
+        <version.com.dyuproject.protostuff>1.0.8</version.com.dyuproject.protostuff>
+        <switchyard.osgi.export.pkg>
+            org.switchyard.serial.protostuff.*
+        </switchyard.osgi.export.pkg>
     </properties>
     <dependencies>
         <!-- internal dependencies -->
+        <dependency>
+            <groupId>org.switchyard</groupId>
+            <artifactId>switchyard-common</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.switchyard</groupId>
             <artifactId>switchyard-serial</artifactId>
@@ -38,32 +45,51 @@
         <dependency>
             <groupId>com.dyuproject.protostuff</groupId>
             <artifactId>protostuff-api</artifactId>
-            <version>${version.protostuff}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.dyuproject.protostuff</groupId>
-            <artifactId>protostuff-collectionschema</artifactId>
-            <version>${version.protostuff}</version>
         </dependency>
         <dependency>
             <groupId>com.dyuproject.protostuff</groupId>
             <artifactId>protostuff-core</artifactId>
-            <version>${version.protostuff}</version>
         </dependency>
         <dependency>
             <groupId>com.dyuproject.protostuff</groupId>
             <artifactId>protostuff-json</artifactId>
-            <version>${version.protostuff}</version>
         </dependency>
         <dependency>
             <groupId>com.dyuproject.protostuff</groupId>
             <artifactId>protostuff-runtime</artifactId>
-            <version>${version.protostuff}</version>
         </dependency>
         <dependency>
             <groupId>com.dyuproject.protostuff</groupId>
             <artifactId>protostuff-xml</artifactId>
-            <version>${version.protostuff}</version>
         </dependency>
     </dependencies>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.dyuproject.protostuff</groupId>
+                <artifactId>protostuff-api</artifactId>
+                <version>${version.com.dyuproject.protostuff}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.dyuproject.protostuff</groupId>
+                <artifactId>protostuff-core</artifactId>
+                <version>${version.com.dyuproject.protostuff}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.dyuproject.protostuff</groupId>
+                <artifactId>protostuff-json</artifactId>
+                <version>${version.com.dyuproject.protostuff}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.dyuproject.protostuff</groupId>
+                <artifactId>protostuff-runtime</artifactId>
+                <version>${version.com.dyuproject.protostuff}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.dyuproject.protostuff</groupId>
+                <artifactId>protostuff-xml</artifactId>
+                <version>${version.com.dyuproject.protostuff}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 </project>

--- a/serial/protostuff/src/test/java/org/switchyard/serial/protostuff/ProtostuffComparisonSerializationTest.java
+++ b/serial/protostuff/src/test/java/org/switchyard/serial/protostuff/ProtostuffComparisonSerializationTest.java
@@ -13,8 +13,7 @@
  */
 package org.switchyard.serial.protostuff;
 
-import junit.framework.Assert;
-
+import org.junit.Assert;
 import org.junit.Test;
 import org.switchyard.serial.CompressionType;
 import org.switchyard.serial.FormatType;

--- a/serial/protostuff/src/test/java/org/switchyard/serial/protostuff/ProtostuffComplexSerializationTest.java
+++ b/serial/protostuff/src/test/java/org/switchyard/serial/protostuff/ProtostuffComplexSerializationTest.java
@@ -14,6 +14,7 @@
 package org.switchyard.serial.protostuff;
 
 import java.io.StringReader;
+import java.lang.reflect.UndeclaredThrowableException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -24,8 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-import junit.framework.Assert;
-
+import org.junit.Assert;
 import org.junit.Test;
 import org.switchyard.HandlerException;
 import org.switchyard.common.io.pull.ElementPuller;
@@ -215,6 +215,23 @@ public final class ProtostuffComplexSerializationTest {
         Assert.assertEquals(expectedOutOfGasException.getExplicitive(), actualOutOfGasException.getExplicitive());
         Assert.assertSame(expectedFlatTireException.getWheel().getLocation(), actualFlatTireException.getWheel().getLocation());
         Assert.assertEquals("Really?", actualFlatTireException.getMessage());
+    }
+
+    @Test
+    public void testUndeclaredThrowableException() throws Exception {
+        final UndeclaredThrowableException expectedUndeclaredThrowableException = new UndeclaredThrowableException(new Throwable("undeclared"), "message");
+        Car car = new Car();
+        car.setProblems(Arrays.asList(new Exception[]{expectedUndeclaredThrowableException, expectedUndeclaredThrowableException}));
+        car = serDeser(car, Car.class);
+        final List<Exception> actualExceptions = car.getProblems();
+        final UndeclaredThrowableException actualUndeclaredThrowableException = (UndeclaredThrowableException)actualExceptions.get(0);
+        final UndeclaredThrowableException sameUndeclaredThrowableException = (UndeclaredThrowableException)actualExceptions.get(1);
+        Assert.assertSame(actualUndeclaredThrowableException, sameUndeclaredThrowableException);
+        Assert.assertEquals("message", actualUndeclaredThrowableException.getMessage());
+        Assert.assertEquals(expectedUndeclaredThrowableException.getMessage(), actualUndeclaredThrowableException.getMessage());
+        Assert.assertEquals(expectedUndeclaredThrowableException.getStackTrace().length, actualUndeclaredThrowableException.getStackTrace().length);
+        Assert.assertEquals("undeclared", actualUndeclaredThrowableException.getUndeclaredThrowable().getMessage());
+        Assert.assertSame(actualUndeclaredThrowableException.getUndeclaredThrowable(), actualUndeclaredThrowableException.getCause());
     }
 
     @Test


### PR DESCRIPTION
SWITCHYARD-2416: Exception not thrown when remote SCA fails while unmarshalling object
https://issues.jboss.org/browse/SWITCHYARD-2416
